### PR TITLE
Add display method option when text overflows cell area

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_install:
 
 before_script:
   - npm run lint
-  - npm run build
+  - npm run build:ci
   - npm run check
 
 deploy:

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "scripts": {
     "test": "mrpm run test",
     "build": "mrpm run build",
+    "build:ci": "mrpm run build:ci",
     "prune:all": "mrpm prune",
     "lint": "mrpm run lint",
     "echo:v": "echo $npm_package_version",

--- a/packages/cheetah-grid/package.json
+++ b/packages/cheetah-grid/package.json
@@ -55,7 +55,8 @@
     "eslint:fix": "eslint . --fix",
     "test:font-svg-to-icons-js-loader": "node webpack/test/font-svg-to-icons-js-loader/test.js",
     "test:svg-to-icon-js-loader": "node webpack/test/svg-to-icon-js-loader/test.js",
-    "test:loader": "npm run test:font-svg-to-icons-js-loader && npm run test:svg-to-icon-js-loader"
+    "test:loader": "npm run test:font-svg-to-icons-js-loader && npm run test:svg-to-icon-js-loader",
+    "build:ci": "npm run build"
   },
   "directories": {
     "src": "src/js",

--- a/packages/cheetah-grid/src/js/GridCanvasHelper.js
+++ b/packages/cheetah-grid/src/js/GridCanvasHelper.js
@@ -141,7 +141,10 @@ function breakWidthInlines(ctx, inlines, width) {
 	const beforeInlines = inlines.slice(0, index);
 	const afterInlines = [];
 	if (inline.canBreak()) {
-		let {before, after} = inline.breakAll(ctx, remWidth);
+		let {before, after} = inline.breakWord(ctx, remWidth);
+		if (!before && !beforeInlines.length) {
+			({before, after} = inline.breakAll(ctx, remWidth));
+		}
 		if (!before && !beforeInlines.length) { // Always return one char
 			({before, after} = inline.splitIndex(1));
 		}

--- a/packages/cheetah-grid/src/js/ListGrid.js
+++ b/packages/cheetah-grid/src/js/ListGrid.js
@@ -11,6 +11,7 @@ const {DataSource, CachedDataSource} = require('./data');
 const themes = require('./themes');
 const icons = require('./internal/icons');
 const MessageHandler = require('./columns/message/MessageHandler');
+const TooltipHandler = require('./tooltip/TooltipHandler');
 const EVENT_TYPE = require('./list-grid/EVENT_TYPE');
 
 //protected symbol
@@ -555,6 +556,7 @@ class ListGrid extends DrawGrid {
 		this[_].gridCanvasHelper = new GridCanvasHelper(this);
 		this[_].theme = themes.of(options.theme);
 		this[_].messageHandler = new MessageHandler(this, (col, row) => _getCellMessage(this, col, row));
+		this[_].tooltipHandler = new TooltipHandler(this);
 		this.invalidate();
 		this[_].handler.on(window, 'resize', () => {
 			this.updateSize();
@@ -564,6 +566,7 @@ class ListGrid extends DrawGrid {
 	}
 	dispose() {
 		this[_].messageHandler.dispose();
+		this[_].tooltipHandler.dispose();
 		super.dispose();
 	}
 	/**

--- a/packages/cheetah-grid/src/js/columns/style/MultilineTextStyle.js
+++ b/packages/cheetah-grid/src/js/columns/style/MultilineTextStyle.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const Style = require('./Style');
 
 function adj(style) {
@@ -15,6 +14,8 @@ class MultilineTextStyle extends Style {
 	constructor(style = {}) {
 		super(adj(style));
 		this._lineHeight = style.lineHeight || '1em';
+		this._autoWrapText = style.autoWrapText || false;
+		this._lineClamp = style.lineClamp;
 	}
 	clone() {
 		return new MultilineTextStyle(this);
@@ -26,7 +27,19 @@ class MultilineTextStyle extends Style {
 		this._lineHeight = lineHeight;
 		this.doChangeStyle();
 	}
+	get lineClamp() {
+		return this._lineClamp;
+	}
+	set lineClamp(lineClamp) {
+		this._lineClamp = lineClamp;
+		this.doChangeStyle();
+	}
+	get autoWrapText() {
+		return this._autoWrapText;
+	}
+	set autoWrapText(autoWrapText) {
+		this._autoWrapText = autoWrapText;
+		this.doChangeStyle();
+	}
 }
-
-
 module.exports = MultilineTextStyle;

--- a/packages/cheetah-grid/src/js/columns/style/Style.js
+++ b/packages/cheetah-grid/src/js/columns/style/Style.js
@@ -11,6 +11,7 @@ class Style extends StdBaseStyle {
 		this._color = style.color;
 		this._font = style.font;
 		this._padding = style.padding;
+		this._textOverflow = style.textOverflow || 'clip';
 	}
 	get color() {
 		return this._color;
@@ -31,6 +32,13 @@ class Style extends StdBaseStyle {
 	}
 	set padding(padding) {
 		this._padding = padding;
+		this.doChangeStyle();
+	}
+	get textOverflow() {
+		return this._textOverflow;
+	}
+	set textOverflow(textOverflow) {
+		this._textOverflow = textOverflow;
 		this.doChangeStyle();
 	}
 	clone() {

--- a/packages/cheetah-grid/src/js/columns/type/ButtonColumn.js
+++ b/packages/cheetah-grid/src/js/columns/type/ButtonColumn.js
@@ -29,7 +29,16 @@ class ButtonColumn extends Column {
 		return this._caption || value;
 	}
 	drawInternal(value, context, style, helper, grid, {drawCellBase, getIcon}) {
-		const {textAlign, textBaseline, bgColor, color, buttonBgColor, font, padding} = style;
+		const {
+			textAlign,
+			textBaseline,
+			bgColor,
+			color,
+			buttonBgColor,
+			font,
+			padding,
+			textOverflow
+		} = style;
 		if (bgColor) {
 			drawCellBase({
 				bgColor,
@@ -62,6 +71,7 @@ class ButtonColumn extends Column {
 					blur: 6,
 					offsetY: 3,
 				} : true,
+				textOverflow,
 				icons,
 			});
 		});

--- a/packages/cheetah-grid/src/js/columns/type/Column.js
+++ b/packages/cheetah-grid/src/js/columns/type/Column.js
@@ -19,6 +19,7 @@ class Column extends BaseColumn {
 			font,
 			bgColor,
 			padding,
+			textOverflow,
 		} = style;
 		if (bgColor) {
 			drawCellBase({
@@ -32,8 +33,9 @@ class Column extends BaseColumn {
 				textBaseline,
 				color,
 				font,
-				icons,
 				padding,
+				textOverflow,
+				icons,
 			});
 		});
 	}

--- a/packages/cheetah-grid/src/js/columns/type/MenuColumn.js
+++ b/packages/cheetah-grid/src/js/columns/type/MenuColumn.js
@@ -32,6 +32,7 @@ class MenuColumn extends BaseColumn {
 			font,
 			bgColor,
 			padding,
+			textOverflow,
 		} = style;
 		let {
 			color,
@@ -57,8 +58,9 @@ class MenuColumn extends BaseColumn {
 				textBaseline,
 				color,
 				font,
-				icons,
 				padding: textPadding,
+				textOverflow,
+				icons,
 			});
 			// draw icon
 			helper.text('', context, {

--- a/packages/cheetah-grid/src/js/columns/type/MultilineTextColumn.js
+++ b/packages/cheetah-grid/src/js/columns/type/MultilineTextColumn.js
@@ -1,5 +1,4 @@
 'use strict';
-
 const MultilineTextStyle = require('../style/MultilineTextStyle');
 const BaseColumn = require('./BaseColumn');
 const utils = require('./columnUtils');
@@ -22,6 +21,9 @@ class MultilineTextColumn extends BaseColumn {
 			bgColor,
 			padding,
 			lineHeight,
+			autoWrapText,
+			lineClamp,
+			textOverflow
 		} = style;
 		if (bgColor) {
 			drawCellBase({
@@ -36,9 +38,12 @@ class MultilineTextColumn extends BaseColumn {
 				textBaseline,
 				color,
 				font,
-				icons,
 				padding,
 				lineHeight,
+				autoWrapText,
+				lineClamp,
+				textOverflow,
+				icons,
 			});
 		});
 	}

--- a/packages/cheetah-grid/src/js/core/DrawGrid.js
+++ b/packages/cheetah-grid/src/js/core/DrawGrid.js
@@ -1866,6 +1866,7 @@ class DrawGrid extends EventTarget {
 		this[_].cellSelector = new CellSelector(this);
 
 		this[_].drawCells = {};
+		this[_].cellTextOverflows = {};
 
 		this[_].element.appendChild(this[_].canvas);
 		this[_].element.appendChild(this[_].scrollable.getElement());
@@ -2306,6 +2307,31 @@ class DrawGrid extends EventTarget {
 	 */
 	onDrawCell(col, row, context) {
 		//Please implement cell drawing!!
+	}
+	/**
+	 * Get the overflowed text in the cell rectangle, from the given cell.
+	 * @param  {number} col The column index.
+	 * @param  {number} row The row index
+	 * @return {string | null} The text overflowing the cell rect.
+	 */
+	getCellOverflowText(col, row) {
+		const key = `${col}:${row}`;
+		return this[_].cellTextOverflows[key] || null;
+	}
+	/**
+	 * Set the overflowed text in the cell rectangle, to the given cell.
+	 * @param  {number} col The column index.
+	 * @param  {number} row The row index
+	 * @param  {boolean} overflowText The overflowed text in the cell rectangle.
+	 * @return {void}
+	 */
+	setCellOverflowText(col, row, overflowText) {
+		const key = `${col}:${row}`;
+		if (overflowText) {
+			this[_].cellTextOverflows[key] = typeof overflowText === 'string' ? overflowText.trim() : overflowText;
+		} else {
+			delete this[_].cellTextOverflows[key];
+		}
 	}
 	addDisposable(disposable) {
 		if (!disposable || !disposable.dispose || typeof disposable.dispose !== 'function') {

--- a/packages/cheetah-grid/src/js/element/Inline.js
+++ b/packages/cheetah-grid/src/js/element/Inline.js
@@ -42,5 +42,8 @@ class Inline {
 					}
 				});
 	}
+	toString() {
+		return this._content || '';
+	}
 }
 module.exports = Inline;

--- a/packages/cheetah-grid/src/js/element/Inline.js
+++ b/packages/cheetah-grid/src/js/element/Inline.js
@@ -48,7 +48,22 @@ class Inline {
 				});
 	}
 	canBreak() {
-		return true;
+		return !!this._content;
+	}
+	splitIndex(index) {
+		const content = this._content;
+		const itr = genChars(content);
+		const chars = [];
+		let ret = itr.next();
+		for (let i = 0; i < index && ret !== null; i++, ret = itr.next()) {
+			chars.push(ret);
+		}
+		const beforeContent = chars.join('');
+		const afterContent = content.slice(beforeContent.length);
+		return {
+			before: beforeContent ? new Inline(beforeContent) : null,
+			after: afterContent ? new Inline(afterContent) : null,
+		};
 	}
 	breakAll(ctx, width) {
 		const content = this._content;
@@ -83,8 +98,8 @@ class Inline {
 		const beforeContent = chars.join('');
 		const afterContent = content.slice(beforeContent.length);
 		return {
-			before: new Inline(beforeContent),
-			after: new Inline(afterContent),
+			before: beforeContent ? new Inline(beforeContent) : null,
+			after: afterContent ? new Inline(afterContent) : null,
 		};
 	}
 	toString() {

--- a/packages/cheetah-grid/src/js/element/Inline.js
+++ b/packages/cheetah-grid/src/js/element/Inline.js
@@ -1,12 +1,17 @@
 'use strict';
 
-const {isDef} = require('../internal/utils');
+const {isDef, str: {genChars}} = require('../internal/utils');
+
+function getWidth(ctx, content) {
+	return ctx.measureText(content).width;
+}
+
 class Inline {
 	constructor(content) {
 		this._content = isDef(content) ? content : '';
 	}
 	width({ctx}) {
-		return ctx.measureText(this._content).width;
+		return getWidth(ctx, this._content);
 	}
 	font() {
 		return null;
@@ -42,8 +47,48 @@ class Inline {
 					}
 				});
 	}
+	canBreak() {
+		return true;
+	}
+	breakAll(ctx, width) {
+		const content = this._content;
+		const allWidth = this.width({ctx});
+		const candidate = Math.floor(this._content.length * width / allWidth);
+		const itr = genChars(content);
+		const chars = [];
+		let ret = itr.next();
+		for (let i = 0; i < candidate && ret !== null; i++, ret = itr.next()) {
+			chars.push(ret);
+		}
+		let beforeWidth = getWidth(ctx, chars.join(''));
+		if (beforeWidth > width) {
+			while (chars.length) {
+				const c = chars.pop();
+				beforeWidth -= getWidth(ctx, c);
+				if (beforeWidth <= width) {
+					break;
+				}
+			}
+		} else if (beforeWidth < width) {
+			while (ret !== null) {
+				const charWidth = getWidth(ctx, ret);
+				if (beforeWidth + charWidth > width) {
+					break;
+				}
+				chars.push(ret);
+				beforeWidth += charWidth;
+				ret = itr.next();
+			}
+		}
+		const beforeContent = chars.join('');
+		const afterContent = content.slice(beforeContent.length);
+		return {
+			before: new Inline(beforeContent),
+			after: new Inline(afterContent),
+		};
+	}
 	toString() {
-		return this._content || '';
+		return this._content;
 	}
 }
 module.exports = Inline;

--- a/packages/cheetah-grid/src/js/element/InlineDrawer.js
+++ b/packages/cheetah-grid/src/js/element/InlineDrawer.js
@@ -54,6 +54,12 @@ class InlineDrawer extends Inline {
 			offsetBottom,
 		});
 	}
+	canBreak() {
+		return false;
+	}
+	toString() {
+		return '';
+	}
 }
 
 module.exports = InlineDrawer;

--- a/packages/cheetah-grid/src/js/element/InlineIcon.js
+++ b/packages/cheetah-grid/src/js/element/InlineIcon.js
@@ -67,6 +67,12 @@ class InlineIcon extends Inline {
 					});
 		}
 	}
+	canBreak() {
+		return false;
+	}
+	toString() {
+		return '';
+	}
 }
 
 module.exports = InlineIcon;

--- a/packages/cheetah-grid/src/js/element/InlineImage.js
+++ b/packages/cheetah-grid/src/js/element/InlineImage.js
@@ -96,6 +96,12 @@ class InlineImage extends Inline {
 				});
 
 	}
+	canBreak() {
+		return false;
+	}
+	toString() {
+		return '';
+	}
 }
 
 module.exports = InlineImage;

--- a/packages/cheetah-grid/src/js/element/InlinePath2D.js
+++ b/packages/cheetah-grid/src/js/element/InlinePath2D.js
@@ -68,6 +68,12 @@ class InlinePath2D extends Inline {
 			ctx.restore();
 		}
 	}
+	canBreak() {
+		return false;
+	}
+	toString() {
+		return '';
+	}
 }
 
 module.exports = InlinePath2D;

--- a/packages/cheetah-grid/src/js/element/InlineSvg.js
+++ b/packages/cheetah-grid/src/js/element/InlineSvg.js
@@ -39,6 +39,12 @@ class InlineSvg extends InlineImage {
 			imageHeight: elmHeight,
 		});
 	}
+	canBreak() {
+		return false;
+	}
+	toString() {
+		return '';
+	}
 }
 
 module.exports = InlineSvg;

--- a/packages/cheetah-grid/src/js/element/inlines.js
+++ b/packages/cheetah-grid/src/js/element/inlines.js
@@ -137,5 +137,8 @@ module.exports = {
 			}
 		}
 		return result;
+	},
+	string(inline) {
+		return this.buildInlines(undefined, inline).join('');
 	}
 };

--- a/packages/cheetah-grid/src/js/header/style/BaseStyle.js
+++ b/packages/cheetah-grid/src/js/header/style/BaseStyle.js
@@ -16,28 +16,10 @@ class BaseStyle extends EventTarget {
 	}
 	constructor(
 			{
-				textAlign = 'left',
-				textBaseline = 'middle',
 				bgColor
 			} = {}) {
 		super();
-		this._textAlign = textAlign;
-		this._textBaseline = textBaseline;
 		this._bgColor = bgColor;
-	}
-	get textAlign() {
-		return this._textAlign;
-	}
-	set textAlign(textAlign) {
-		this._textAlign = textAlign;
-		this.doChangeStyle();
-	}
-	get textBaseline() {
-		return this._textBaseline;
-	}
-	set textBaseline(textBaseline) {
-		this._textBaseline = textBaseline;
-		this.doChangeStyle();
 	}
 	get bgColor() {
 		return this._bgColor;

--- a/packages/cheetah-grid/src/js/header/style/StdBaseStyle.js
+++ b/packages/cheetah-grid/src/js/header/style/StdBaseStyle.js
@@ -1,0 +1,33 @@
+'use strict';
+
+const BaseStyle = require('./BaseStyle');
+
+let defaultStyle;
+class StdBaseStyle extends BaseStyle {
+	static get DEFAULT() {
+		return defaultStyle ? defaultStyle : (defaultStyle = new StdBaseStyle());
+	}
+	constructor(style = {}) {
+		super(style);
+		this._textAlign = style.textAlign || 'left';
+		this._textBaseline = style.textBaseline || 'middle';
+	}
+	get textAlign() {
+		return this._textAlign;
+	}
+	set textAlign(textAlign) {
+		this._textAlign = textAlign;
+		this.doChangeStyle();
+	}
+	get textBaseline() {
+		return this._textBaseline;
+	}
+	set textBaseline(textBaseline) {
+		this._textBaseline = textBaseline;
+		this.doChangeStyle();
+	}
+	clone() {
+		return new StdBaseStyle(this);
+	}
+}
+module.exports = StdBaseStyle;

--- a/packages/cheetah-grid/src/js/header/style/Style.js
+++ b/packages/cheetah-grid/src/js/header/style/Style.js
@@ -1,20 +1,36 @@
 'use strict';
 
-const BaseStyle = require('./BaseStyle');
+const StdBaseStyle = require('./StdBaseStyle');
 let defaultStyle;
-class Style extends BaseStyle {
+class Style extends StdBaseStyle {
 	static get DEFAULT() {
 		return defaultStyle ? defaultStyle : (defaultStyle = new Style());
 	}
 	constructor(style = {}) {
 		super(style);
 		this._color = style.color;
+		this._font = style.font;
+		this._textOverflow = style.textOverflow || 'ellipsis';
 	}
 	get color() {
 		return this._color;
 	}
 	set color(color) {
 		this._color = color;
+		this.doChangeStyle();
+	}
+	get font() {
+		return this._font;
+	}
+	set font(font) {
+		this._font = font;
+		this.doChangeStyle();
+	}
+	get textOverflow() {
+		return this._textOverflow;
+	}
+	set textOverflow(textOverflow) {
+		this._textOverflow = textOverflow;
 		this.doChangeStyle();
 	}
 	clone() {

--- a/packages/cheetah-grid/src/js/header/type/Header.js
+++ b/packages/cheetah-grid/src/js/header/type/Header.js
@@ -15,6 +15,7 @@ class Header extends BaseHeader {
 			color,
 			font,
 			bgColor,
+			textOverflow,
 		} = style;
 
 		if (bgColor) {
@@ -28,6 +29,7 @@ class Header extends BaseHeader {
 			textBaseline,
 			color,
 			font,
+			textOverflow,
 		});
 	}
 	bindGridEvent(grid) {

--- a/packages/cheetah-grid/src/js/header/type/SortHeader.js
+++ b/packages/cheetah-grid/src/js/header/type/SortHeader.js
@@ -28,6 +28,7 @@ class SortHeader extends BaseHeader {
 			color,
 			bgColor,
 			font,
+			textOverflow,
 		} = style;
 
 		if (bgColor) {
@@ -50,6 +51,7 @@ class SortHeader extends BaseHeader {
 			textBaseline,
 			color,
 			font,
+			textOverflow,
 			icons: [{
 				name: isDef(order) ? (order === 'asc' ? 'arrow_downward' : 'arrow_upward') : null,
 				width: arrowSize,

--- a/packages/cheetah-grid/src/js/internal/utils.js
+++ b/packages/cheetah-grid/src/js/internal/utils.js
@@ -119,6 +119,15 @@ function endsWith(str, searchString, position) {
 	const lastIndex = subjectString.lastIndexOf(searchString, position);
 	return lastIndex !== -1 && lastIndex === position;
 }
+function toChars(s) {
+	// Surrogate Code Point
+	// [\uD800-\uDBFF]
+	// Variation Selectors
+	// FVS [\u180B-\u180D]
+	// VS1～VS16 [\uFE00-\uFE0F]
+	// VS17～VS256 \uDB40[\uDD00-\uDDEF]
+	return s.match(/([\uD800-\uDBFF][\uDC00-\uDFFF]|\r\n|[^\uD800-\uDFFF])([\u180B-\u180D]|[\s\S][\uFE00-\uFE0F]|\uDB40[\uDD00-\uDDEF])?/g) || [];
+}
 const isPromise = (data) => data && typeof data.then === 'function';
 const then = (result, callback) => isPromise(result) ? result.then((r) => callback(r)) : callback(result);
 function getMouseButtons(e) {
@@ -219,7 +228,8 @@ module.exports = {
 		isObject,
 	},
 	str: {
-		endsWith
+		endsWith,
+		toChars
 	},
 	event: {
 		getMouseButtons,

--- a/packages/cheetah-grid/src/js/internal/utils.js
+++ b/packages/cheetah-grid/src/js/internal/utils.js
@@ -119,14 +119,20 @@ function endsWith(str, searchString, position) {
 	const lastIndex = subjectString.lastIndexOf(searchString, position);
 	return lastIndex !== -1 && lastIndex === position;
 }
-function toChars(s) {
+function genChars(s) {
 	// Surrogate Code Point
 	// [\uD800-\uDBFF]
 	// Variation Selectors
 	// FVS [\u180B-\u180D]
 	// VS1～VS16 [\uFE00-\uFE0F]
 	// VS17～VS256 \uDB40[\uDD00-\uDDEF]
-	return s.match(/([\uD800-\uDBFF][\uDC00-\uDFFF]|\r\n|[^\uD800-\uDFFF])([\u180B-\u180D]|[\s\S][\uFE00-\uFE0F]|\uDB40[\uDD00-\uDDEF])?/g) || [];
+	const re = /([\uD800-\uDBFF][\uDC00-\uDFFF]|\r\n|[^\uD800-\uDFFF])([\u180B-\u180D]|[\s\S][\uFE00-\uFE0F]|\uDB40[\uDD00-\uDDEF])?/g;
+	return {
+		next() {
+			const res = re.exec(s);
+			return res !== null ? res[0] : null;
+		}
+	};
 }
 const isPromise = (data) => data && typeof data.then === 'function';
 const then = (result, callback) => isPromise(result) ? result.then((r) => callback(r)) : callback(result);
@@ -229,7 +235,7 @@ module.exports = {
 	},
 	str: {
 		endsWith,
-		toChars
+		genChars
 	},
 	event: {
 		getMouseButtons,

--- a/packages/cheetah-grid/src/js/internal/utils.js
+++ b/packages/cheetah-grid/src/js/internal/utils.js
@@ -126,7 +126,16 @@ function genChars(s) {
 	// FVS [\u180B-\u180D]
 	// VS1～VS16 [\uFE00-\uFE0F]
 	// VS17～VS256 \uDB40[\uDD00-\uDDEF]
-	const re = /([\uD800-\uDBFF][\uDC00-\uDFFF]|\r\n|[^\uD800-\uDFFF])([\u180B-\u180D]|[\s\S][\uFE00-\uFE0F]|\uDB40[\uDD00-\uDDEF])?/g;
+	const re = /([\uD800-\uDBFF][\uDC00-\uDFFF]|\r\n|[^\uD800-\uDFFF])([\u180B-\u180D]|[\uFE00-\uFE0F]|\uDB40[\uDD00-\uDDEF])?/g;
+	return {
+		next() {
+			const res = re.exec(s);
+			return res !== null ? res[0] : null;
+		}
+	};
+}
+function genWords(s) {
+	const re = /[!-~]+|[^!-~\s]+|\s+/g;
 	return {
 		next() {
 			const res = re.exec(s);
@@ -235,7 +244,8 @@ module.exports = {
 	},
 	str: {
 		endsWith,
-		genChars
+		genChars,
+		genWords
 	},
 	event: {
 		getMouseButtons,

--- a/packages/cheetah-grid/src/js/tooltip/BaseTooltip.js
+++ b/packages/cheetah-grid/src/js/tooltip/BaseTooltip.js
@@ -1,0 +1,34 @@
+'use strict';
+
+class BaseTooltip {
+	constructor(grid) {
+		this._grid = grid;
+	}
+	dispose() {
+		this.detachTooltipElement();
+		if (this._tooltipElement) {
+			this._tooltipElement.dispose();
+		}
+		this._tooltipElement = null;
+	}
+	_getTooltipElement() {
+		return this._tooltipElement || (this._tooltipElement = this.createTooltipElementInternal());
+	}
+	createTooltipElementInternal() {
+
+	}
+	attachTooltipElement(col, row, content) {
+		const tooltipElement = this._getTooltipElement();
+		tooltipElement.attach(this._grid, col, row, content);
+	}
+	moveTooltipElement(col, row) {
+		const tooltipElement = this._getTooltipElement();
+		tooltipElement.move(this._grid, col, row);
+	}
+	detachTooltipElement() {
+		const tooltipElement = this._getTooltipElement();
+		tooltipElement._detach();
+	}
+}
+
+module.exports = BaseTooltip;

--- a/packages/cheetah-grid/src/js/tooltip/Tooltip.js
+++ b/packages/cheetah-grid/src/js/tooltip/Tooltip.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const BaseTooltip = require('./BaseTooltip');
+const TooltipElement = require('./internal/TooltipElement');
+
+class Tooltip extends BaseTooltip {
+	createTooltipElementInternal() {
+		return new TooltipElement();
+	}
+}
+
+module.exports = Tooltip;

--- a/packages/cheetah-grid/src/js/tooltip/TooltipHandler.js
+++ b/packages/cheetah-grid/src/js/tooltip/TooltipHandler.js
@@ -1,0 +1,125 @@
+'use strict';
+
+const {
+	SELECTED_CELL,
+	SCROLL,
+	CHANGED_VALUE,
+	MOUSEOVER_CELL,
+	MOUSEOUT_CELL
+} = require('../list-grid/EVENT_TYPE');
+const Tooltip = require('./Tooltip');
+
+const TOOLTIP_INSTANCE_FACTORY = {
+	'overflow-text'(grid) {
+		return new Tooltip(grid);
+	},
+};
+
+function getTooltipInstanceInfo(grid, col, row) {
+	//
+	// overflow text tooltip
+	const overflowText = grid.getCellOverflowText(col, row);
+	if (overflowText) {
+		return {
+			type: 'overflow-text',
+			content: overflowText
+		};
+	}
+	return null;
+}
+
+class TooltipHandler {
+	constructor(grid) {
+		this._grid = grid;
+		this._tooltipInstances = {};
+		this._bindGridEvent(grid);
+	}
+	dispose() {
+		const tooltipInstances = this._tooltipInstances;
+		for (const k in tooltipInstances) {
+			tooltipInstances[k].dispose();
+		}
+		this._tooltipInstances = null;
+	}
+	_attach(col, row) {
+		const info = this._attachInfo;
+		const instanceInfo = this._getTooltipInstanceInfo(col, row);
+		if (info && (!instanceInfo || info.instance !== instanceInfo.instance)) {
+			info.instance.detachTooltipElement();
+			this._attachInfo = null;
+		}
+		if (!instanceInfo) {
+			return;
+		}
+		const {instance} = instanceInfo;
+		instance.attachTooltipElement(col, row, instanceInfo.content);
+		this._attachInfo = {col, row, instance};
+	}
+	_move(col, row) {
+		const info = this._attachInfo;
+		if (!info || info.col !== col || info.row !== row) {
+			return;
+		}
+		const {instance} = info;
+		instance.moveTooltipElement(col, row);
+	}
+	_detach() {
+		const info = this._attachInfo;
+		if (!info) {
+			return;
+		}
+		const {instance} = info;
+		instance.detachTooltipElement();
+		this._attachInfo = null;
+	}
+	_isAttachCell(col, row) {
+		const info = this._attachInfo;
+		if (!info) {
+			return false;
+		}
+		return (info.col === col && info.row === row);
+	}
+	_bindGridEvent(grid) {
+		grid.listen(MOUSEOVER_CELL, (e) => {
+			this._attach(e.col, e.row);
+		});
+		grid.listen(MOUSEOUT_CELL, (e) => {
+			this._detach();
+		});
+		grid.listen(SELECTED_CELL, (e) => {
+			if (this._isAttachCell(e.col, e.row)) {
+				this._detach(e);
+			}
+		});
+		grid.listen(SCROLL, () => {
+			const info = this._attachInfo;
+			if (!info) {
+				return;
+			}
+			this._move(info.col, info.row);
+		});
+		grid.listen(CHANGED_VALUE, (e) => {
+			if (this._isAttachCell(e.col, e.row)) {
+				this._detach();
+				this._attach(e.col, e.row);
+			}
+		});
+	}
+	_getTooltipInstanceInfo(col, row) {
+		const grid = this._grid;
+		const tooltipInstances = this._tooltipInstances;
+		const info = getTooltipInstanceInfo(grid, col, row);
+		if (!info) {
+			return null;
+		}
+		const {type} = info;
+		const instance = tooltipInstances[type] || (tooltipInstances[type] = TOOLTIP_INSTANCE_FACTORY[type](grid));
+		return {
+			instance,
+			type,
+			content: info.content
+		};
+	}
+}
+
+module.exports = TooltipHandler;

--- a/packages/cheetah-grid/src/js/tooltip/internal/TooltipElement.css
+++ b/packages/cheetah-grid/src/js/tooltip/internal/TooltipElement.css
@@ -1,0 +1,44 @@
+@keyframes cheetah-grid__tooltip-element--shown-animation {
+	0% {
+		opacity: 0;
+		transform: scale(.8) translateX(-60%);
+	}
+	100% {
+		opacity: 1;
+		transform: scale(1) translateX(-50%);
+	}
+}
+
+.cheetah-grid__tooltip-element {
+	position: absolute;
+	box-sizing: border-box;
+	border-radius: 3px;
+	background-color: #232F34;
+	padding: 8px;
+
+	pointer-events: none;
+	user-select: none;
+}
+.cheetah-grid__tooltip-element--hidden {
+	opacity: 0;
+	transform: translateX(-50%);
+	transition: opacity 75ms linear;
+}
+.cheetah-grid__tooltip-element--shown {
+	opacity: 1;
+	transform: translateX(-50%);
+	animation: cheetah-grid__tooltip-element--shown-animation 150ms ease-out;
+}
+.cheetah-grid__tooltip-element__content {
+	font-family: Roboto;
+	font-size: 12px;
+	font-size: .75rem;
+	min-height: 1em;
+	line-height: 1;
+	display: block;
+	width: 100%;
+	margin: 0;
+}
+.cheetah-grid__tooltip-element {
+	color: #FFFFFF;
+}

--- a/packages/cheetah-grid/src/js/tooltip/internal/TooltipElement.css
+++ b/packages/cheetah-grid/src/js/tooltip/internal/TooltipElement.css
@@ -35,8 +35,9 @@
 	font-size: .75rem;
 	min-height: 1em;
 	line-height: 1;
-	display: block;
 	width: 100%;
+	display: block;
+	white-space: pre-wrap;
 	margin: 0;
 }
 .cheetah-grid__tooltip-element {

--- a/packages/cheetah-grid/src/js/tooltip/internal/TooltipElement.js
+++ b/packages/cheetah-grid/src/js/tooltip/internal/TooltipElement.js
@@ -1,0 +1,120 @@
+'use strict';
+const EventHandler = require('../../internal/EventHandler');
+const {
+	createElement,
+} = require('../../internal/dom');
+
+const CLASSNAME = 'cheetah-grid__tooltip-element';
+const CONTENT_CLASSNAME = `${CLASSNAME}__content`;
+const HIDDEN_CLASSNAME = `${CLASSNAME}--hidden`;
+const SHOWN_CLASSNAME = `${CLASSNAME}--shown`;
+
+function createTooltipDomElement() {
+	require('./TooltipElement.css');
+	const rootElement = createElement('div', {classList: [CLASSNAME, HIDDEN_CLASSNAME]});
+	const messageElement = createElement('pre', {classList: [CONTENT_CLASSNAME]});
+	rootElement.appendChild(messageElement);
+	return rootElement;
+}
+
+
+class TooltipElement {
+	constructor() {
+		this._handler = new EventHandler();
+		const rootElement = this._rootElement = createTooltipDomElement();
+		this._messageElement = rootElement.querySelector(`.${CONTENT_CLASSNAME}`);
+	}
+	dispose() {
+		this.detach();
+
+		const rootElement = this._rootElement;
+		if (rootElement.parentElement) {
+			rootElement.parentElement.removeChild(rootElement);
+		}
+
+		this._handler.dispose();
+		this._rootElement = null;
+		this._messageElement = null;
+	}
+	attach(grid, col, row, content) {
+		const rootElement = this._rootElement;
+		const messageElement = this._messageElement;
+
+		rootElement.classList.remove(SHOWN_CLASSNAME);
+		rootElement.classList.add(HIDDEN_CLASSNAME);
+
+		if (this._attachCell(grid, col, row)) {
+			rootElement.classList.add(SHOWN_CLASSNAME);
+			rootElement.classList.remove(HIDDEN_CLASSNAME);
+
+			messageElement.textContent = content;
+		} else {
+			this._detach();
+		}
+	}
+	move(grid, col, row) {
+		const rootElement = this._rootElement;
+		if (this._attachCell(grid, col, row)) {
+
+			rootElement.classList.add(SHOWN_CLASSNAME);
+			rootElement.classList.remove(HIDDEN_CLASSNAME);
+		} else {
+			this._detach();
+		}
+	}
+	detach() {
+		this._detach();
+	}
+	_detach() {
+		const rootElement = this._rootElement;
+		if (rootElement.parentElement) {
+			// rootElement.parentElement.removeChild(rootElement);
+			rootElement.classList.remove(SHOWN_CLASSNAME);
+			rootElement.classList.add(HIDDEN_CLASSNAME);
+		}
+	}
+	_attachCell(grid, col, row) {
+		const rootElement = this._rootElement;
+		const {element, rect} = grid.getAttachCellArea(col, row);
+
+		const {bottom: top, left, width} = rect;
+		const {frozenRowCount, frozenColCount} = grid;
+		if (row >= frozenRowCount && frozenRowCount > 0) {
+			const {rect: frozenRect} = grid.getAttachCellArea(col, frozenRowCount - 1);
+			if (top < frozenRect.bottom) {
+				return false;//範囲外
+			}
+		} else {
+			if (top < 0) {
+				return false;//範囲外
+			}
+		}
+		if (col >= frozenColCount && frozenColCount > 0) {
+			const {rect: frozenRect} = grid.getAttachCellArea(frozenColCount - 1, row);
+			if (left < frozenRect.right) {
+				return false;//範囲外
+			}
+		} else {
+			if (left < 0) {
+				return false;//範囲外
+			}
+		}
+		const {offsetHeight, offsetWidth} = element;
+		if (offsetHeight < top) {
+			return false;//範囲外
+		}
+		if (offsetWidth < left) {
+			return false;//範囲外
+		}
+
+		rootElement.style.top = `${top.toFixed()}px`;
+		rootElement.style.left = `${(left + width / 2).toFixed()}px`;
+		rootElement.style['min-width'] = `${width.toFixed()}px`;
+		if (rootElement.parentElement !== element) {
+			element.appendChild(rootElement);
+		}
+		return true;
+	}
+}
+
+module.exports = TooltipElement;

--- a/packages/cheetah-grid/src/test/specs/apis/textOverflow_spec.html
+++ b/packages/cheetah-grid/src/test/specs/apis/textOverflow_spec.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>test</title>
+    <script src="http://localhost:35729/livereload.js"></script>
+    <link rel="stylesheet" type="text/css" href="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.5.2/jasmine.css">
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.5.2/jasmine.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.5.2/jasmine-html.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jasmine/2.5.2/boot.js"></script>
+    <script type="text/javascript" src="https://unpkg.com/image-matcher@0.1"></script>
+
+    <script type="text/javascript" src="../../../../dist/cheetahGrid.es5.js"></script>
+    <style type="text/css">
+    </style>
+</head>
+<body>
+    <div id="main"></div>
+    
+    <script type="text/javascript" src="../test-helper.js"></script>
+	<script type="text/javascript" src="textOverflow_spec.js"></script>
+</body>
+</html>

--- a/packages/cheetah-grid/src/test/specs/apis/textOverflow_spec.js
+++ b/packages/cheetah-grid/src/test/specs/apis/textOverflow_spec.js
@@ -1,0 +1,306 @@
+/*global cheetahGrid*/
+/*eslint-env es6*/
+/*eslint prefer-arrow-callback:"off", object-shorthand:"off", max-len: "off", prefer-destructuring:"off"*/
+'use strict';
+(function() {
+	let mainEl = document.querySelector('#main');
+	if (!mainEl) {
+		mainEl = document.createElement('div');
+		mainEl.id = 'main';
+		document.body.appendChild(mainEl);
+	}
+
+	const records = [
+		{},
+		{},
+	];
+
+	function createGrid(header, opt) {
+		opt = opt || {};
+
+		const grid = new cheetahGrid.ListGrid({
+			parentElement: (function() {
+				const parent = document.createElement('div');
+				parent.id = 'parent';
+				parent.style.width = '500px';
+				parent.style.height = '300px';
+				mainEl.appendChild(parent);
+				return parent;
+			})(),
+			defaultRowHeight: opt.defaultRowHeight || 24,
+			defaultColWidth: opt.defaultColWidth || 50,
+			header: header,
+			records: opt.records || records,
+		});
+
+		const theme = {};
+		theme.frozenRowsBgColor = '#d3d3d3';
+		grid.theme = cheetahGrid.themes.choices.BASIC.extends(theme);
+		return grid;
+	}
+
+
+	describe('textOverflow', function() {
+
+
+		function createAnswerCanvasBase(grid, opt) {
+			opt = opt || {};
+			const rows = (() => {
+				const result = [];
+				for (let i = 0; i < grid.rowCount; i++) {
+					result.push(grid.getRowHeight(i));
+				}
+				return result;
+			})();
+			const cols = (() => {
+				const result = [];
+				for (let i = 0; i < grid.colCount; i++) {
+					result.push(grid.getColWidth(i));
+				}
+				return result;
+			})();
+
+			const canvasHelper = window.createCanvasHelper(grid.canvas.width, grid.canvas.height);
+			const ctx = canvasHelper.context;
+			ctx.font = '16px sans-serif';
+
+			const girdHelper = canvasHelper.createGridHelper(cols, rows);
+
+			//塗りつぶし
+			canvasHelper.fillRect('#f6f6f6');
+			girdHelper.fillRect('white');
+			girdHelper.fillRect('#d3d3d3', 0, 0, null, 0);
+			girdHelper.fillRect('#f6f6f6', 0, 2, null, 1);
+
+			//罫線
+			girdHelper.lineAll(1);
+			ctx.strokeStyle = '#5e9ed6';
+			girdHelper.lineH(1, 0, 0, 0);
+			girdHelper.lineH(2, 0, 0, 0, true);
+			girdHelper.lineV(1, 0, 0, 0);
+			girdHelper.lineV(2, 0, 0, 0, true);
+
+
+			return {
+				canvasHelper: canvasHelper,
+				girdHelper: girdHelper,
+			};
+
+		}
+
+		it('textOverflow="ellipsis"', function(done) {
+
+			const grid = createGrid([
+				{field() {
+					return 'VALUE';
+				},
+				caption: 'TEST_',
+				width: 50,
+				style: {
+					textOverflow: 'ellipsis'
+				}},
+			]);
+			function createAnswerCanvas() {
+
+				const base = createAnswerCanvasBase(grid);
+				const canvasHelper = base.canvasHelper;
+				const ctx = canvasHelper.context;
+
+				const girdHelper = base.girdHelper;
+
+				//TEXT
+				ctx.fillStyle = '#000';
+				const textOpt = {
+					offset: 3,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				};
+				girdHelper.text('TES\u2026', 0, 0, textOpt);
+				girdHelper.text('VAL\u2026', 0, 1, {
+					offset: 4,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				});
+				girdHelper.text('VAL\u2026', 0, 2, {
+					offset: 4,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				});
+
+
+				return canvasHelper.canvas;
+			}
+			const canvas = createAnswerCanvas();
+			setTimeout(function() {
+				expect(grid.canvas).toMatchImage(canvas, {tolerance: 110, delta: '20%', blurLevel: 1});
+				expect(grid.getCellOverflowText(0, 1)).toBe('VALUE');
+				done();
+			}, 200);
+
+		});
+
+
+		it('textOverflow="ellipsis" on multiline', function(done) {
+
+			const grid = createGrid([
+				{field() {
+					return 'VALUE\nVALUE';
+				},
+				caption: 'TEST_',
+				width: 50,
+				columnType: 'multilinetext',
+				style: {
+					textOverflow: 'ellipsis'
+				}},
+			], {defaultRowHeight: 50});
+			function createAnswerCanvas() {
+
+				const base = createAnswerCanvasBase(grid);
+				const canvasHelper = base.canvasHelper;
+				const ctx = canvasHelper.context;
+
+				const girdHelper = base.girdHelper;
+
+				const em = ctx.measureText('あ').width;
+
+				//TEXT
+				ctx.fillStyle = '#000';
+				const textOpt = {
+					offset: 3,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				};
+				girdHelper.text('TES\u2026', 0, 0, textOpt);
+				girdHelper.text('VAL\u2026', 0, 1, {
+					y: 61,
+					offset: 4,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				});
+				girdHelper.text('VAL\u2026', 0, 1, {
+					y: 61 + em,
+					offset: 4,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				});
+				girdHelper.text('VAL\u2026', 0, 2, {
+					y: 111,
+					offset: 4,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				});
+				girdHelper.text('VAL\u2026', 0, 2, {
+					y: 111 + Number(em),
+					offset: 4,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				});
+
+
+				return canvasHelper.canvas;
+			}
+			const canvas = createAnswerCanvas();
+			setTimeout(function() {
+				expect(grid.canvas).toMatchImage(canvas, {tolerance: 200, delta: '30%', blurLevel: 1});
+				expect(grid.getCellOverflowText(0, 1)).toBe('VALUE\nVALUE');
+				done();
+			}, 200);
+
+		});
+
+
+		it('lineClamp="auto" autoWrapText=true on multiline', function(done) {
+
+			const grid = createGrid([
+				{field() {
+					return 'VALUE\nVALUE\nVALUE';
+				},
+				caption: 'TEST_',
+				width: 50,
+				columnType: 'multilinetext',
+				style: {
+					lineClamp: 'auto',
+					autoWrapText: true,
+				}},
+			], {defaultRowHeight: 50, records: [{}]});
+			function createAnswerCanvas() {
+
+				const base = createAnswerCanvasBase(grid);
+				const canvasHelper = base.canvasHelper;
+				const ctx = canvasHelper.context;
+
+				const girdHelper = base.girdHelper;
+
+				const em = ctx.measureText('あ').width;
+
+				const lineClamp = Math.floor(50 / em);
+
+				//TEXT
+				ctx.fillStyle = '#000';
+				const textOpt = {
+					offset: 3,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				};
+				girdHelper.text('TES\u2026', 0, 0, textOpt);
+				girdHelper.text('VALU', 0, 1, {
+					y: 61,
+					offset: 4,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				});
+				girdHelper.text('E', 0, 1, {
+					y: 61 + em,
+					offset: 4,
+					textBaseline: 'middle',
+					textAlign: 'left',
+				});
+				if (lineClamp === 3) {
+					girdHelper.text('VAL\u2026', 0, 1, {
+						y: 61 + em + em,
+						offset: 4,
+						textBaseline: 'middle',
+						textAlign: 'left',
+					});
+				} else {
+					girdHelper.text('VALU', 0, 1, {
+						y: 61 + em + em,
+						offset: 4,
+						textBaseline: 'middle',
+						textAlign: 'left',
+					});
+					if (lineClamp === 4) {
+						girdHelper.text('E\u2026', 0, 1, {
+							y: 61 + em + em + em,
+							offset: 4,
+							textBaseline: 'middle',
+							textAlign: 'left',
+						});
+					} else {
+						girdHelper.text('E', 0, 1, {
+							y: 61 + em + em + em,
+							offset: 4,
+							textBaseline: 'middle',
+							textAlign: 'left',
+						});
+						girdHelper.text('VAL\u2026', 0, 1, {
+							y: 61 + em + em + em + em,
+							offset: 4,
+							textBaseline: 'middle',
+							textAlign: 'left',
+						});
+					}
+				}
+				return canvasHelper.canvas;
+			}
+			const canvas = createAnswerCanvas();
+			setTimeout(function() {
+				expect(grid.canvas).toMatchImage(canvas, {tolerance: 210, delta: '25%', blurLevel: 1});
+				expect(grid.getCellOverflowText(0, 1)).toBe('VALUE\nVALUE\nVALUE');
+				done();
+			}, 200);
+
+		});
+
+	});
+})();

--- a/packages/cheetah-grid/src/test/specs/apis/textOverflow_spec.js
+++ b/packages/cheetah-grid/src/test/specs/apis/textOverflow_spec.js
@@ -117,12 +117,12 @@
 				};
 				girdHelper.text('TES\u2026', 0, 0, textOpt);
 				girdHelper.text('VAL\u2026', 0, 1, {
-					offset: 4,
+					offset: 3,
 					textBaseline: 'middle',
 					textAlign: 'left',
 				});
 				girdHelper.text('VAL\u2026', 0, 2, {
-					offset: 4,
+					offset: 3,
 					textBaseline: 'middle',
 					textAlign: 'left',
 				});
@@ -243,49 +243,51 @@
 					textAlign: 'left',
 				};
 				girdHelper.text('TES\u2026', 0, 0, textOpt);
+
+				const valTop = 62;
 				girdHelper.text('VALU', 0, 1, {
-					y: 61,
-					offset: 4,
+					y: valTop,
+					offset: 3,
 					textBaseline: 'middle',
 					textAlign: 'left',
 				});
 				girdHelper.text('E', 0, 1, {
-					y: 61 + em,
-					offset: 4,
+					y: valTop + em,
+					offset: 3,
 					textBaseline: 'middle',
 					textAlign: 'left',
 				});
 				if (lineClamp === 3) {
 					girdHelper.text('VAL\u2026', 0, 1, {
-						y: 61 + em + em,
-						offset: 4,
+						y: valTop + em * 2,
+						offset: 3,
 						textBaseline: 'middle',
 						textAlign: 'left',
 					});
 				} else {
 					girdHelper.text('VALU', 0, 1, {
-						y: 61 + em + em,
-						offset: 4,
+						y: valTop + em * 2,
+						offset: 3,
 						textBaseline: 'middle',
 						textAlign: 'left',
 					});
 					if (lineClamp === 4) {
 						girdHelper.text('E\u2026', 0, 1, {
-							y: 61 + em + em + em,
-							offset: 4,
+							y: valTop + em * 3,
+							offset: 3,
 							textBaseline: 'middle',
 							textAlign: 'left',
 						});
 					} else {
 						girdHelper.text('E', 0, 1, {
-							y: 61 + em + em + em,
-							offset: 4,
+							y: valTop + em * 3,
+							offset: 3,
 							textBaseline: 'middle',
 							textAlign: 'left',
 						});
 						girdHelper.text('VAL\u2026', 0, 1, {
-							y: 61 + em + em + em + em,
-							offset: 4,
+							y: valTop + em * 4,
+							offset: 3,
 							textBaseline: 'middle',
 							textAlign: 'left',
 						});
@@ -295,7 +297,7 @@
 			}
 			const canvas = createAnswerCanvas();
 			setTimeout(function() {
-				expect(grid.canvas).toMatchImage(canvas, {tolerance: 210, delta: '25%', blurLevel: 1});
+				expect(grid.canvas).toMatchImage(canvas, {tolerance: 210, delta: '25%', blurLevel: 1, log: true});
 				expect(grid.getCellOverflowText(0, 1)).toBe('VALUE\nVALUE\nVALUE');
 				done();
 			}, 200);

--- a/packages/cheetah-grid/src/test/specs/column/style/CheckStyle_spec.js
+++ b/packages/cheetah-grid/src/test/specs/column/style/CheckStyle_spec.js
@@ -32,7 +32,7 @@
 			{field: 'str', caption: 'str', width: 50, columnType: 'check', style: style, action: action},
 			{field: 'onoff', caption: 'onoff', width: 50, columnType: 'check', style: style, action: action},
 			{field: 'num', caption: 'num', width: 50, columnType: 'check', style: style, action: action},
-			{field: 'numstr', caption: 'numstr', width: 50, columnType: 'check', style: style, action: action},
+			{field: 'numstr', caption: 'nstr', width: 50, columnType: 'check', style: style, action: action},
 		],
 		records: records,
 	});
@@ -80,7 +80,7 @@
 			girdHelper.text('str', 1, 0, textOpt);
 			girdHelper.text('onoff', 2, 0, textOpt);
 			girdHelper.text('num', 3, 0, textOpt);
-			girdHelper.text('numstr', 4, 0, textOpt);
+			girdHelper.text('nstr', 4, 0, textOpt);
 
 			return {
 				canvasHelper: canvasHelper,
@@ -140,7 +140,7 @@
 					row: 2,
 				},
 			})).toEqual([
-				'bool	str	onoff	num	numstr\n' +
+				'bool	str	onoff	num	nstr\n' +
 				'true	true	on	1	01\n' +
 				'false	false	off	0	000\n'
 			]);

--- a/packages/cheetah-grid/src/test/specs/column/type/CheckColumn_spec.js
+++ b/packages/cheetah-grid/src/test/specs/column/type/CheckColumn_spec.js
@@ -30,7 +30,7 @@
 			{field: 'str', caption: 'str', width: 50, columnType: 'check', action: 'check'},
 			{field: 'onoff', caption: 'onoff', width: 50, columnType: 'check', action: 'check'},
 			{field: 'num', caption: 'num', width: 50, columnType: 'check', action: 'check'},
-			{field: 'numstr', caption: 'numstr', width: 50, columnType: 'check', action: 'check'},
+			{field: 'numstr', caption: 'nstr', width: 50, columnType: 'check', action: 'check'},
 		],
 		records: records,
 	});
@@ -78,7 +78,7 @@
 			girdHelper.text('str', 1, 0, textOpt);
 			girdHelper.text('onoff', 2, 0, textOpt);
 			girdHelper.text('num', 3, 0, textOpt);
-			girdHelper.text('numstr', 4, 0, textOpt);
+			girdHelper.text('nstr', 4, 0, textOpt);
 
 			return {
 				canvasHelper: canvasHelper,
@@ -134,7 +134,7 @@
 					row: 2,
 				},
 			})).toEqual([
-				'bool	str	onoff	num	numstr\n' +
+				'bool	str	onoff	num	nstr\n' +
 				'true	true	on	1	01\n' +
 				'false	false	off	0	000\n'
 			]);
@@ -166,7 +166,7 @@
 					return canvas;
 				}
 				const canvas = createAnswerCanvas();
-				expect(grid.canvas).toMatchImage(canvas, {tolerance: 20, delta: '20%', blurLevel: 1});
+				expect(grid.canvas).toMatchImage(canvas, {tolerance: 30, delta: '20%', blurLevel: 1});
 
 				done();
 

--- a/packages/demo/src/vue/EnterprisePage.vue
+++ b/packages/demo/src/vue/EnterprisePage.vue
@@ -35,7 +35,8 @@
         <c-grid-icon-column
           :width="150"
           :column-style="{
-            color: 'gold'
+            color: 'gold',
+            textOverflow: 'ellipsis'
           }"
           :action="{
             actionName: 'InlineMenuEditor',
@@ -61,6 +62,9 @@
             :helper-text="value => { return `${value.length}/20` }"
             :input-validator="value => { return value.length > 20 ? `over the max length. ${value.length}` : null }"
             :message="firstNameValidateMessage"
+            :column-style="{
+              textOverflow: 'ellipsis'
+            }"
             input-class-list= "helper-text--right-justified"
             field= "fname"
             width= "20%"
@@ -71,6 +75,9 @@
             :helper-text="value => { return `${value.length}/20` }"
             :input-validator="value => { return value.length > 20 ? `over the max length. ${value.length}` : null }"
             :message="lastNameValidateMessage"
+            :column-style="{
+              textOverflow: 'ellipsis'
+            }"
             input-class-list= "helper-text--right-justified"
             field="lname"
             width= "20%"
@@ -84,7 +91,8 @@
           :formatter="v => { return v ? `${v}%` : '' }"
           :column-style="{
             textAlign: 'right',
-            padding: [0, 10, 0, 0]
+            padding: [0, 10, 0, 0],
+            textOverflow: 'ellipsis'
           }"
           :action="{
             actionName: 'SmallDialogInputEditor',
@@ -110,6 +118,9 @@
             return ret ? null : 'Please enter email addr.'
           }"
           :message="emailValidateMessage"
+          :column-style="{
+            textOverflow: 'ellipsis'
+          }"
           helper-text="Email"
           field="email"
           width="calc(50% - 505px - 20px)"
@@ -128,6 +139,9 @@
           }"
           :validator="value => { return isNaN(new Date(value)) ? 'Please enter date.' : null }"
           :message="birthdayValidateMessage"
+          :column-style="{
+            textOverflow: 'ellipsis'
+          }"
           helper-text="birthday"
           width="100"
           filter="dateFormat('yyyy/m/d')"
@@ -136,6 +150,9 @@
         </c-grid-input-column>
         <c-grid-button-column
           :width="120"
+          :column-style="{
+            textOverflow: 'ellipsis'
+          }"
           caption="SHOW REC"
           @click="clickRec"
         />

--- a/packages/docs/scripts/buildcommon.js
+++ b/packages/docs/scripts/buildcommon.js
@@ -1,5 +1,5 @@
 'use strict';
-
+const semver = require('semver');
 let watchMode = false;
 let devMode = false;
 for (let i = 0; i < process.argv.length; i++) {
@@ -11,42 +11,8 @@ for (let i = 0; i < process.argv.length; i++) {
 	}
 }
 
-const packageVersion = require('../../cheetah-grid/package.json').version;
+const packageVersion = require('../package.json').version;
 // const latestVersion = require('./versions.json')[0];
-function versionCompare(v1, v2) {
-	const v1parts = v1.split('.');
-	const v2parts = v2.split('.');
-
-	function isValidPart(x) {
-		return (/^\d+$/).test(x);
-	}
-	if (!v1parts.every(isValidPart) || !v2parts.every(isValidPart)) {
-		return NaN;
-	}
-
-	while (v1parts.length < v2parts.length) { v1parts.push('9999'); }
-	while (v2parts.length < v1parts.length) { v2parts.push('9999'); }
-
-	for (let i = 0; i < v1parts.length; ++i) {
-		if (v2parts.length === i) {
-			return 1;
-		}
-
-		if (v1parts[i] === v2parts[i]) {
-			continue;
-		} else if ((v1parts[i] - 0) > (v2parts[i] - 0)) {
-			return 1;
-		} else {
-			return -1;
-		}
-	}
-
-	if (v1parts.length !== v2parts.length) {
-		return -1;
-	}
-
-	return 0;
-}
 const com = {
 	getDocumentVersion() {
 		if (watchMode || devMode) {
@@ -55,16 +21,14 @@ const com = {
 		if (packageVersion === '0.0.1') {
 			return packageVersion;
 		}
-		const [major, minor/*, patch*/] = packageVersion.split('.');
-		return `${major}.${minor}`;
+		return `${semver.major(packageVersion)}.${semver.minor(packageVersion)}`;
 	},
 	isEnabledVersion(v) {
-		return versionCompare(v, packageVersion) <= 0;
+		return semver.lte(v, packageVersion);
 	},
 	packageVersion,
 	get packageVersionX() {
-		const p = packageVersion.split('.');
-		return `${p[0]}.${p[1]}.x`;
+		return `${semver.major(packageVersion)}.${semver.minor(packageVersion)}.x`;
 	},
 	watchMode,
 	devMode,

--- a/packages/docs/src/demos/usage/column_styles.html.hbs
+++ b/packages/docs/src/demos/usage/column_styles.html.hbs
@@ -14,10 +14,15 @@ order: 120
 
 |property|説明|
 |---|---|
-|color|セルのテキスト色を指定できます|
-|textAlign|セルのテキスト横位置を指定できます|
-|textBaseline|セルのテキスト縦位置を指定できます|
-|bgColor|セルの背景色を指定できます|
+|color|セルのテキスト色を指定できます。|
+|textAlign|セルのテキスト横位置を指定できます。|
+|textBaseline|セルのテキスト縦位置を指定できます。|
+|bgColor|セルの背景色を指定できます。|
+|font|フォントを指定できます。|
+|padding|パディングを指定できます。|
+{{#if_v '0.6.0'}}
+|textOverflow|テキストがセルをオーバーフローした場合の表示方法を指定できます。`clip`・`ellipsis`が利用できます。|
+{{/if_v }}
 {{else}}
 Define column style by using `style` property.  
 
@@ -25,11 +30,16 @@ Properties below are prepared in standard.
 
 |property|description|
 |---|---|
-|color|define color of cell|
-|textAlign|define horizontal position of text in cell|
-|textBaseline|define vertical position of text in cell|
-|bgColor|define background color of cell|
+|color|define color of cell.|
+|textAlign|define horizontal position of text in cell.|
+|textBaseline|define vertical position of text in cell.|
+|bgColor|define background color of cell.|
+|font|define font of cell.|
+|padding|define padding of cell. if you set 4 values separately, please set the `Array`.|
 {{/if}}
+{{#if_v '0.6.0'}}
+|textOverflow|define how to display when text overflows the area of a cell. `clip` or `ellipsis` is available.|
+{{/if_v }}
 {{/marked}}
 
 <div id="sample1" class="demo-grid small">
@@ -44,20 +54,23 @@ const grid = new cheetahGrid.ListGrid({
 	header: [
 		{field: 'no', caption: 'no', width: 50},
 
-		//default
+		// default
 		{field: 'text', caption: 'default', width: 150},
 
-		//color
+		// color
 		{field: 'text', caption: 'color', width: 150, style: {color: 'red'}},
-		//textAlign
+		// textAlign
 		{field: 'text', caption: 'right', width: 150, style: {textAlign: 'right'}},
 		{field: 'text', caption: 'center', width: 150, style: {textAlign: 'center'}},
-		//textBaseline
+		// textBaseline
 		{field: 'text', caption: 'top', width: 150, style: {textBaseline: 'top'}},
 		{field: 'text', caption: 'bottom', width: 150, style: {textBaseline: 'bottom'}},
 
-		//bgColor
+		// bgColor
 		{field: 'text', caption: 'bgColor', width: 150, style: {bgColor: '#5f5'}},
+
+		// font
+		{field: 'text', caption: 'font', width: 150, style: {font: '9px sans-serif'}},
 	],
 });
 grid.records = [
@@ -69,6 +82,43 @@ grid.records = [
 //{{/wrapscript}}
 </script>
 {{> code class="js" code=script1}}
+
+
+<div id="sample2" class="demo-grid middle">
+</div>
+<script type="text/javascript">
+//{{#wrapscript}}
+//{{#copy "script2"}}
+/*global cheetahGrid*/
+'use strict';
+const grid = new cheetahGrid.ListGrid({
+	parentElement: document.querySelector('#sample2'),
+	header: [
+		{field: 'no', caption: 'no', width: 50},
+
+		// default
+		{field: 'text', caption: 'default', width: 150},
+
+		// padding
+		{field: 'text', caption: 'padding', width: 150, style: {padding: 20}},
+		{field: 'text', caption: 'padding', width: 150, style: {padding: [0/*top*/, 10/*right*/, 15/*bottom*/, 20/*left*/]}},
+
+		//{{#if_v '0.6.0'}} textOverflow
+		{field: 'longText', caption: 'textOverflow', width: 150, style: {textOverflow: 'ellipsis'}},
+		//{{/if_v }}
+	],
+	defaultRowHeight: 80,
+	headerRowHeight: 24,
+});
+grid.records = [
+	{no: 1, text: 'sample text', longText: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'},
+	{no: 2, text: 'sample text', longText: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'},
+	{no: 3, text: 'sample text', longText: 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'},
+];
+//{{/copy}}
+//{{/wrapscript}}
+</script>
+{{> code class="js" code=script2}}
 
 {{#marked}}
 
@@ -93,22 +143,22 @@ This can be done by functions below.
 {{/if}}
 {{/marked}}
 
-<div id="sample2" class="demo-grid small">
+<div id="sample3" class="demo-grid small">
 </div>
 <label>change background color of text</label>
-<select id="sample2theme">
+<select id="sample3theme">
     <option value="" selected="true">default</option>
     <option value="red">red</option>
     <option value="#DFF">#DFF</option>
 </select>
 <script type="text/javascript">
 //{{#wrapscript}}
-//{{#copy "script2"}}
+//{{#copy "script3"}}
 /*global cheetahGrid*/
 'use strict';
 const textFieldStyle = new cheetahGrid.columns.style.Style();
 const grid = new cheetahGrid.ListGrid({
-	parentElement: document.querySelector('#sample2'),
+	parentElement: document.querySelector('#sample3'),
 	header: [
 		{field: 'no', caption: 'no', width: 50},
 
@@ -141,7 +191,7 @@ grid.records = [
 	{no: 4, text: 'sample text', value: -50},
 ];
 
-const themeSelect = document.querySelector('#sample2theme');
+const themeSelect = document.querySelector('#sample3theme');
 themeSelect.onchange = function() {
 	//change bg color
 	if (themeSelect.value === 'default') {
@@ -153,5 +203,5 @@ themeSelect.onchange = function() {
 //{{/copy}}
 //{{/wrapscript}}
 </script>
-{{> code class="js" code=script2}}
+{{> code class="js" code=script3}}
 

--- a/packages/docs/src/demos/usage/column_types/MultilineTextColumn.html.hbs
+++ b/packages/docs/src/demos/usage/column_types/MultilineTextColumn.html.hbs
@@ -92,30 +92,10 @@ JavaScriptグリッドコンポーネントです。
 
 
 
-{{#marked}}
-## Styles
-
-{{#if lang_ja}}
-{{else}}
-{{/if}}
-
-
-
-### Aligns
-{{/marked}}
-<div id="sample2" class="demo-grid large">
-</div>
-{{#marked}}
-### lineHeight
-{{/marked}}
-<div id="sample3" class="demo-grid large">
-</div>
 <script type="text/javascript">
-//{{#wrapscript}}
-/*global cheetahGrid*/
 'use strict';
-
-const records = [
+//{{#wrapscript}}
+window.records = [
 	{
 		title: 'multilinetext',
 		description:
@@ -145,149 +125,244 @@ JavaScriptグリッドコンポーネントです。
 ストレスなく100万レコードを表示できます。`
 	},
 ];
-{
-	const grid = new cheetahGrid.ListGrid({
-		parentElement: document.querySelector('#sample2'),
-		//{{#copy "sample2"}}
-		header: [
-			{
-				field: 'title',
-				caption: 'title',
-				width: 250,
-			},
-			//textAlign
-			{
-				field: 'description',
-				caption: 'left',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {textAlign: 'left'}
-			},
-			{
-				field: 'description',
-				caption: 'right',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {textAlign: 'right'}
-			},
-			{
-				field: 'description',
-				caption: 'center',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {textAlign: 'center'}
-			},
-			//textBaseline
-			{
-				field: 'description',
-				caption: 'top',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {textBaseline: 'top'}
-			},
-			{
-				field: 'description',
-				caption: 'middle',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {textBaseline: 'middle'}
-			},
-			{
-				field: 'description',
-				caption: 'bottom',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {textBaseline: 'bottom'}
-			},
-		],
-		//{{/copy}}
-		frozenColCount: 1,
-		defaultRowHeight: 200,
-		headerRowHeight: 40,
-	});
-	grid.records = records;
-}
-{
-	const grid = new cheetahGrid.ListGrid({
-		parentElement: document.querySelector('#sample3'),
-		//{{#copy "sample3"}}
-		header: [
-			{
-				field: 'title',
-				caption: 'title',
-				width: 250,
-			},
-			//textAlign
-			{
-				field: 'description',
-				caption: 'lineHeight=3em left',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {
-					lineHeight: '3em',
-					textAlign: 'left'
-				}
-			},
-			{
-				field: 'description',
-				caption: 'lineHeight=3em right',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {
-					lineHeight: '3em',
-					textAlign: 'right'
-				}
-			},
-			{
-				field: 'description',
-				caption: 'lineHeight=3em center',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {
-					lineHeight: '3em',
-					textAlign: 'center'
-				}
-			},
-			//textBaseline
-			{
-				field: 'description',
-				caption: 'lineHeight=3em top',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {
-					lineHeight: '3em',
-					textBaseline: 'top'
-				}
-			},
-			{
-				field: 'description',
-				caption: 'lineHeight=3em middle',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {
-					lineHeight: '3em',
-					textBaseline: 'middle'
-				}
-			},
-			{
-				field: 'description',
-				caption: 'lineHeight=3em bottom',
-				width: 600,
-				columnType: 'multilinetext',
-				style: {
-					lineHeight: '3em',
-					textBaseline: 'bottom'
-				}
-			},
-		],
-		//{{/copy}}
-		frozenColCount: 1,
-		defaultRowHeight: 300,
-		headerRowHeight: 40,
-	});
-	grid.records = records;
-}
+//{{/wrapscript}}
+</script>
+
+{{#marked}}
+## Styles
+
+{{#if lang_ja}}
+{{else}}
+{{/if}}
+
+
+
+### Aligns
+{{/marked}}
+<div id="sample2" class="demo-grid large">
+</div>
+<script type="text/javascript">
+'use strict';
+//{{#wrapscript}}
+/*global cheetahGrid*/
+const grid = new cheetahGrid.ListGrid({
+	parentElement: document.querySelector('#sample2'),
+	//{{#copy "sample2"}}
+	header: [
+		{
+			field: 'title',
+			caption: 'title',
+			width: 250,
+		},
+		//textAlign
+		{
+			field: 'description',
+			caption: 'left',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {textAlign: 'left'}
+		},
+		{
+			field: 'description',
+			caption: 'right',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {textAlign: 'right'}
+		},
+		{
+			field: 'description',
+			caption: 'center',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {textAlign: 'center'}
+		},
+		//textBaseline
+		{
+			field: 'description',
+			caption: 'top',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {textBaseline: 'top'}
+		},
+		{
+			field: 'description',
+			caption: 'middle',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {textBaseline: 'middle'}
+		},
+		{
+			field: 'description',
+			caption: 'bottom',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {textBaseline: 'bottom'}
+		},
+	],
+	//{{/copy}}
+	frozenColCount: 1,
+	defaultRowHeight: 200,
+	headerRowHeight: 40,
+});
+grid.records = window.records;
 //{{/wrapscript}}
 </script>
 {{> code class="js" code=sample2}}
+
+{{#marked}}
+### lineHeight
+{{/marked}}
+<div id="sample3" class="demo-grid large">
+</div>
+<script type="text/javascript">
+'use strict';
+//{{#wrapscript}}
+/*global cheetahGrid*/
+const grid = new cheetahGrid.ListGrid({
+	parentElement: document.querySelector('#sample3'),
+	//{{#copy "sample3"}}
+	header: [
+		{
+			field: 'title',
+			caption: 'title',
+			width: 250,
+		},
+		{
+			field: 'description',
+			caption: 'lineHeight=3em top',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {
+				lineHeight: '3em',
+				textBaseline: 'top'
+			}
+		},
+		{
+			field: 'description',
+			caption: 'lineHeight=3em middle',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {
+				lineHeight: '3em',
+				textBaseline: 'middle'
+			}
+		},
+		{
+			field: 'description',
+			caption: 'lineHeight=3em bottom',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {
+				lineHeight: '3em',
+				textBaseline: 'bottom'
+			}
+		},
+	],
+	//{{/copy}}
+	frozenColCount: 1,
+	defaultRowHeight: 300,
+	headerRowHeight: 40,
+});
+grid.records = window.records;
+//{{/wrapscript}}
+</script>
 {{> code class="js" code=sample3}}
+
+{{#if_v '0.6.0'}}
+{{#marked}}
+### autoWrapText
+{{/marked}}
+<div id="sample4" class="demo-grid small">
+</div>
+<script type="text/javascript">
+'use strict';
+//{{#wrapscript}}
+/*global cheetahGrid*/
+const grid = new cheetahGrid.ListGrid({
+	parentElement: document.querySelector('#sample4'),
+	//{{#copy "sample4"}}
+	header: [
+		{
+			field: 'title',
+			caption: 'title',
+			width: 250,
+		},
+		{
+			field: 'description',
+			caption: 'autoWrapText=true',
+			width: 300,
+			columnType: 'multilinetext',
+			style: {
+				autoWrapText: true
+			}
+		},
+	],
+	//{{/copy}}
+	frozenColCount: 1,
+	defaultRowHeight: 100,
+	headerRowHeight: 40,
+});
+grid.records = window.records;
+//{{/wrapscript}}
+</script>
+{{> code class="js" code=sample4}}
+
+{{#marked}}
+### lineClamp
+{{/marked}}
+<div id="sample5" class="demo-grid small">
+</div>
+<script type="text/javascript">
+'use strict';
+//{{#wrapscript}}
+/*global cheetahGrid*/
+const grid = new cheetahGrid.ListGrid({
+	parentElement: document.querySelector('#sample5'),
+	//{{#copy "sample5"}}
+	header: [
+		{
+			field: 'title',
+			caption: 'title',
+			width: 250,
+		},
+		{
+			field: 'description',
+			caption: 'lineClamp=2 autoWrapText=true',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {
+				autoWrapText: true,
+				lineClamp: 2
+			}
+		},
+		{
+			field: 'description',
+			caption: 'lineClamp="auto" autoWrapText=true',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {
+				autoWrapText: true,
+				lineClamp: 'auto'
+			}
+		},
+		{
+			field: 'description',
+			caption: 'lineClamp=2 textOverflow=ellipsis',
+			width: 600,
+			columnType: 'multilinetext',
+			style: {
+				lineClamp: 2,
+				textOverflow: 'ellipsis'
+			}
+		},
+	],
+	//{{/copy}}
+	frozenColCount: 1,
+	defaultRowHeight: 60,
+	headerRowHeight: 40,
+});
+grid.records = window.records;
+//{{/wrapscript}}
+</script>
+{{> code class="js" code=sample5}}
+{{/if_v}}

--- a/packages/docs/src/demos/usage/column_types/MultilineTextColumn.html.hbs
+++ b/packages/docs/src/demos/usage/column_types/MultilineTextColumn.html.hbs
@@ -41,12 +41,12 @@ const grid = new cheetahGrid.ListGrid({
 		{
 			field: 'title',
 			caption: 'title',
-			width: 250,
+			width: 150,
 		},
 		{
 			field: 'description',
 			caption: 'description',
-			width: 600,
+			width: 'calc(100% - 150px)',
 			columnType: 'multilinetext'
 		},
 	],
@@ -55,6 +55,13 @@ const grid = new cheetahGrid.ListGrid({
 	headerRowHeight: 40,
 });
 grid.records = [
+	{
+		title: 'Lorem ipsum',
+		description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
+	},
 	{
 		title: 'multilinetext',
 		description:
@@ -66,22 +73,6 @@ You can display multiple lines of text in a cell.`
 		description:
 `プロパティ'columnType'に'multilinetext'を指定することで、  
 セルに複数行テキストを表示することができます。  `
-	},
-	{
-		title: 'Cheetah Grid is',
-		description:
-`Cheetah Grid is a high performance JavaScript data table component
-that works on canvas.
-
-You can 1,000,000 records displayed without stress.`
-	},
-	{
-		title: 'Cheetah Gridとは',
-		description:
-`Cheetah Gridは、Canvasで実現する、ハイパフォーマンスな
-JavaScriptグリッドコンポーネントです。
-
-ストレスなく100万レコードを表示できます。`
 	},
 ];
 
@@ -97,6 +88,19 @@ JavaScriptグリッドコンポーネントです。
 //{{#wrapscript}}
 window.records = [
 	{
+		title: 'Lorem ipsum',
+		description: `Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.
+Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.
+Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.
+Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.`
+	},
+	// {{#if_v '0.6.0'}}
+	{
+		title: 'Section 1.10.32',
+		description: 'Sed ut perspiciatis unde omnis iste natus error sit voluptatem accusantium doloremque laudantium, totam rem aperiam, eaque ipsa quae ab illo inventore veritatis et quasi architecto beatae vitae dicta sunt explicabo. Nemo enim ipsam voluptatem quia voluptas sit aspernatur aut odit aut fugit, sed quia consequuntur magni dolores eos qui ratione voluptatem sequi nesciunt. Neque porro quisquam est, qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit, sed quia non numquam eius modi tempora incidunt ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit qui in ea voluptate velit esse quam nihil molestiae consequatur, vel illum qui dolorem eum fugiat quo voluptas nulla pariatur?'
+	},
+	// {{/if_v}}
+	{
 		title: 'multilinetext',
 		description:
 `By specifying 'multilinetext' for the 'columnType' property,
@@ -107,22 +111,6 @@ You can display multiple lines of text in a cell.`
 		description:
 `プロパティ'columnType'に'multilinetext'を指定することで、  
 セルに複数行テキストを表示することができます。  `
-	},
-	{
-		title: 'Cheetah Grid is',
-		description:
-`Cheetah Grid is a high performance JavaScript data table component
-that works on canvas.
-
-You can 1,000,000 records displayed without stress.`
-	},
-	{
-		title: 'Cheetah Gridとは',
-		description:
-`Cheetah Gridは、Canvasで実現する、ハイパフォーマンスな
-JavaScriptグリッドコンポーネントです。
-
-ストレスなく100万レコードを表示できます。`
 	},
 ];
 //{{/wrapscript}}
@@ -152,27 +140,27 @@ const grid = new cheetahGrid.ListGrid({
 		{
 			field: 'title',
 			caption: 'title',
-			width: 250,
+			width: 150,
 		},
 		//textAlign
 		{
 			field: 'description',
 			caption: 'left',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {textAlign: 'left'}
 		},
 		{
 			field: 'description',
 			caption: 'right',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {textAlign: 'right'}
 		},
 		{
 			field: 'description',
 			caption: 'center',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {textAlign: 'center'}
 		},
@@ -180,21 +168,21 @@ const grid = new cheetahGrid.ListGrid({
 		{
 			field: 'description',
 			caption: 'top',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {textBaseline: 'top'}
 		},
 		{
 			field: 'description',
 			caption: 'middle',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {textBaseline: 'middle'}
 		},
 		{
 			field: 'description',
 			caption: 'bottom',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {textBaseline: 'bottom'}
 		},
@@ -225,12 +213,12 @@ const grid = new cheetahGrid.ListGrid({
 		{
 			field: 'title',
 			caption: 'title',
-			width: 250,
+			width: 150,
 		},
 		{
 			field: 'description',
 			caption: 'lineHeight=3em top',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {
 				lineHeight: '3em',
@@ -240,7 +228,7 @@ const grid = new cheetahGrid.ListGrid({
 		{
 			field: 'description',
 			caption: 'lineHeight=3em middle',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {
 				lineHeight: '3em',
@@ -250,7 +238,7 @@ const grid = new cheetahGrid.ListGrid({
 		{
 			field: 'description',
 			caption: 'lineHeight=3em bottom',
-			width: 600,
+			width: 1000,
 			columnType: 'multilinetext',
 			style: {
 				lineHeight: '3em',
@@ -285,12 +273,12 @@ const grid = new cheetahGrid.ListGrid({
 		{
 			field: 'title',
 			caption: 'title',
-			width: 250,
+			width: 150,
 		},
 		{
 			field: 'description',
 			caption: 'autoWrapText=true',
-			width: 300,
+			width: 600,
 			columnType: 'multilinetext',
 			style: {
 				autoWrapText: true
@@ -323,7 +311,7 @@ const grid = new cheetahGrid.ListGrid({
 		{
 			field: 'title',
 			caption: 'title',
-			width: 250,
+			width: 150,
 		},
 		{
 			field: 'description',

--- a/packages/vue-cheetah-grid/package.json
+++ b/packages/vue-cheetah-grid/package.json
@@ -16,7 +16,8 @@
     "watch": "webpack --watch --mode development",
     "lint": "npm run eslint",
     "eslint": "eslint .",
-    "eslint:fix": "eslint . --fix"
+    "eslint:fix": "eslint . --fix",
+    "build:ci": "npm run build"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To allow `textOverflow` to be set with column style options.

```js
{field: '***', caption: '***', style: {textOverflow: 'ellipsis'}},
```

If `'ellipsis'` is set and the text overflows the area of the cell, it displays an ellipsis ('...').

Also, in this state, when you hover to a cell, it will be displaying text in full in a tooltip. ( closes #61 )

#### Other changes
* Change the default header style to `textOverflow: 'ellipsis'`.
* Added style properties related to text overflow to `MultilineTextColumn`.