### PR TITLE
Added `disabled` and `readonly` properties to column components on `vue-cheetah-grid`

### DIFF
--- a/packages/vue-cheetah-grid/lib/CGridButtonColumn.vue
+++ b/packages/vue-cheetah-grid/lib/CGridButtonColumn.vue
@@ -22,13 +22,44 @@ export default {
     caption: {
       type: [String],
       default: ''
+    },
+    /**
+     * Defines disabled
+     */
+    disabled: {
+      type: Boolean
+    }
+  },
+  watch: {
+    disabled (disabled) {
+      if (this._action) {
+        this._action.disabled = disabled
+      }
     }
   },
   methods: {
     /**
      * @private
+     * @override
+     */
+    getPropsObjectInternal () {
+      const props = ColumnMixin.methods.getPropsObjectInternal.apply(this)
+      delete props.disabled
+      return props
+    },
+    /**
+     * @private
      */
     createColumn () {
+      const action = this._action = new cheetahGrid.columns.action.ButtonAction({
+        action: (...args) => {
+          /**
+             * Fired when a click on cell.
+             */
+          this.$emit('click', ...args)
+        },
+        disabled: this.disabled
+      })
       const field = this.filter ? filterToFn(this, this.field, this.filter) : this.field
       return {
         caption: this.$el.textContent.trim(),
@@ -45,14 +76,7 @@ export default {
         columnType: new cheetahGrid.columns.type.ButtonColumn({
           caption: this.caption
         }),
-        action: new cheetahGrid.columns.action.ButtonAction({
-          action: (...args) => {
-            /**
-             * Fired when a click on cell.
-             */
-            this.$emit('click', ...args)
-          }
-        })
+        action
       }
     }
   }

--- a/packages/vue-cheetah-grid/lib/CGridCheckColumn.vue
+++ b/packages/vue-cheetah-grid/lib/CGridCheckColumn.vue
@@ -1,56 +1,43 @@
 <template>
   <!-- Use this slot to set the header caption -->
-  <div class="c-grid-link-column"><slot /></div>
+  <div class="c-grid-check-column"><slot /></div>
 </template>
 
 <script>
 import ColumnMixin from './c-grid/ColumnMixin.vue'
 import StdColumnMixin from './c-grid/StdColumnMixin.vue'
-import { cheetahGrid, filterToFn, normalizeColumnType, girdUpdateWatcher } from './c-grid/utils'
+import { cheetahGrid, filterToFn } from './c-grid/utils'
 
 /**
  * @mixin column-mixin
  * @mixin std-column-mixin
  */
 export default {
-  name: 'CGridLinkColumn',
+  name: 'CGridCheckColumn',
   mixins: [ColumnMixin, StdColumnMixin],
   props: {
-    /**
-     * Defines a column type
-     */
-    columnType: {
-      type: [Object, String, Function],
-      default: undefined
-    },
-    /**
-     * Defines a href
-     */
-    href: {
-      type: [String, Function],
-      default: undefined
-    },
-    /**
-     * Defines an anchor target
-     */
-    target: {
-      type: [String],
-      default: undefined
-    },
     /**
      * Defines disabled
      */
     disabled: {
       type: Boolean
+    },
+    /**
+     * Defines readonly
+     */
+    readonly: {
+      type: Boolean
     }
   },
   watch: {
-    columnType: girdUpdateWatcher,
-    href: girdUpdateWatcher,
-    target: girdUpdateWatcher,
     disabled (disabled) {
       if (this._action) {
         this._action.disabled = disabled
+      }
+    },
+    readonly (readonly) {
+      if (this._action) {
+        this._action.readOnly = readonly
       }
     }
   },
@@ -62,32 +49,23 @@ export default {
     getPropsObjectInternal () {
       const props = ColumnMixin.methods.getPropsObjectInternal.apply(this)
       delete props.disabled
+      delete props.readonly
       return props
     },
     /**
      * @private
      */
     createColumn () {
-      const { href, target = '_blank' } = this
-      const action = typeof href === 'function'
-        ? new cheetahGrid.columns.action.Action({
-          action: href,
-          disabled: this.disabled
-        })
-        : new cheetahGrid.columns.action.Action({
-          action (rec) {
-            window.open(rec[href], target)
-          },
-          disabled: this.disabled
-        })
-      const columnType = normalizeColumnType(this.columnType)
-
+      const action = this._action = new cheetahGrid.columns.action.CheckEditor({
+        disabled: this.disabled,
+        readOnly: this.readonly
+      })
       const field = this.filter ? filterToFn(this, this.field, this.filter) : this.field
       return {
         caption: this.caption || this.$el.textContent.trim(),
         headerStyle: this.headerStyle,
         field,
-        columnType,
+        columnType: 'check',
         width: this.width,
         minWidth: this.minWidth,
         maxWidth: this.maxWidth,
@@ -103,7 +81,7 @@ export default {
 </script>
 
 <style scoped>
-.c-grid-link-column {
+.c-grid-check-column {
   display: none;
 }
 </style>

--- a/packages/vue-cheetah-grid/lib/CGridColumn.vue
+++ b/packages/vue-cheetah-grid/lib/CGridColumn.vue
@@ -6,7 +6,7 @@
 <script>
 import ColumnMixin from './c-grid/ColumnMixin.vue'
 import StdColumnMixin from './c-grid/StdColumnMixin.vue'
-import { filterToFn, normalizeColumnType, normalizeAction } from './c-grid/utils'
+import { filterToFn, normalizeColumnType, normalizeAction, girdUpdateWatcher } from './c-grid/utils'
 
 /**
  * @mixin column-mixin
@@ -30,6 +30,10 @@ export default {
       type: [Object, String, Function],
       default: undefined
     }
+  },
+  watch: {
+    columnType: girdUpdateWatcher,
+    action: girdUpdateWatcher
   },
   methods: {
     /**

--- a/packages/vue-cheetah-grid/lib/CGridColumnGroup.vue
+++ b/packages/vue-cheetah-grid/lib/CGridColumnGroup.vue
@@ -18,9 +18,10 @@ export default {
   methods: {
     /**
      * @private
+     * @override
      */
-    $_CGridColumn_getProps () {
-      const props = ColumnMixin.methods.$_CGridColumn_getProps.apply(this)
+    getPropsObjectInternal () {
+      const props = ColumnMixin.methods.getPropsObjectInternal.apply(this)
       props.columns = slotsToHeaderProps(this.$slots.default)
       return props
     },

--- a/packages/vue-cheetah-grid/lib/CGridIconColumn.vue
+++ b/packages/vue-cheetah-grid/lib/CGridIconColumn.vue
@@ -6,7 +6,7 @@
 <script>
 import ColumnMixin from './c-grid/ColumnMixin.vue'
 import StdColumnMixin from './c-grid/StdColumnMixin.vue'
-import { cheetahGrid, filterToFn, normalizeAction } from './c-grid/utils'
+import { cheetahGrid, filterToFn, normalizeAction, girdUpdateWatcher } from './c-grid/utils'
 
 /**
  * @mixin column-mixin
@@ -58,6 +58,14 @@ export default {
       type: [Object, String, Function],
       default: undefined
     }
+  },
+  watch: {
+    iconTagName: girdUpdateWatcher,
+    iconClassName: girdUpdateWatcher,
+    iconContent: girdUpdateWatcher,
+    iconName: girdUpdateWatcher,
+    iconWidth: girdUpdateWatcher,
+    action: girdUpdateWatcher
   },
   methods: {
     /**

--- a/packages/vue-cheetah-grid/lib/CGridPercentCompleteBarColumn.vue
+++ b/packages/vue-cheetah-grid/lib/CGridPercentCompleteBarColumn.vue
@@ -6,7 +6,7 @@
 <script>
 import ColumnMixin from './c-grid/ColumnMixin.vue'
 import StdColumnMixin from './c-grid/StdColumnMixin.vue'
-import { cheetahGrid, normalizeAction, filterToFn } from './c-grid/utils'
+import { cheetahGrid, normalizeAction, filterToFn, girdUpdateWatcher } from './c-grid/utils'
 
 /**
  * @mixin column-mixin
@@ -44,6 +44,12 @@ export default {
       type: [Object, String, Function],
       default: undefined
     }
+  },
+  watch: {
+    formatter: girdUpdateWatcher,
+    min: girdUpdateWatcher,
+    max: girdUpdateWatcher,
+    action: girdUpdateWatcher
   },
   methods: {
     /**

--- a/packages/vue-cheetah-grid/lib/c-grid/ColumnMixin.vue
+++ b/packages/vue-cheetah-grid/lib/c-grid/ColumnMixin.vue
@@ -1,4 +1,6 @@
 <script>
+import { girdUpdateWatcher } from './utils'
+
 /**
  * The Mixin for `<c-grid-column>` components.
  */
@@ -26,28 +28,51 @@ export default {
       default: undefined
     }
   },
+  watch: {
+    caption: girdUpdateWatcher,
+    sort: girdUpdateWatcher,
+    headerStyle: girdUpdateWatcher
+  },
   mounted () {
-    this.$_CGrid_update()
+    this.$_CGrid_nextTickUpdate()
   },
   updated () {
-    this.$_CGrid_update()
+    this.$_CGrid_nextTickUpdate()
   },
   methods: {
     /**
-     * @private
+     * Redraws the whole grid.
+     * @return {void}
      */
-    $_CGridColumn_getProps () {
+    invalidate () {
+      if (this.$parent && this.$parent.invalidate) {
+        this.$parent.invalidate()
+      }
+    },
+    /**
+     * Returns the property Object to judge the change.
+     * @protected
+     * @returns {object}
+     */
+    getPropsObjectInternal () {
       const props = Object.assign({}, this.$props)
       props.textContent = this.$el.textContent.trim()
       return props
     },
-
     /**
      * @private
      */
     $_CGrid_update () {
       if (this.$parent && this.$parent.$_CGrid_update) {
         this.$parent.$_CGrid_update()
+      }
+    },
+    /**
+     * @private
+     */
+    $_CGrid_nextTickUpdate () {
+      if (this.$parent && this.$parent.$_CGrid_nextTickUpdate) {
+        this.$parent.$_CGrid_nextTickUpdate()
       }
     }
   }

--- a/packages/vue-cheetah-grid/lib/c-grid/StdColumnMixin.vue
+++ b/packages/vue-cheetah-grid/lib/c-grid/StdColumnMixin.vue
@@ -1,4 +1,6 @@
 <script>
+import { girdUpdateWatcher } from './utils'
+
 /**
  * The Mixin for `<c-grid-column>` components.
  * It is used except for `<c-grid-column-group>`.
@@ -61,6 +63,16 @@ export default {
       type: [Object, String, Function],
       default: undefined
     }
+  },
+  watch: {
+    field: girdUpdateWatcher,
+    filter: girdUpdateWatcher,
+    width: girdUpdateWatcher,
+    minWidth: girdUpdateWatcher,
+    maxWidth: girdUpdateWatcher,
+    columnStyle: girdUpdateWatcher,
+    icon: girdUpdateWatcher,
+    message: girdUpdateWatcher
   }
 }
 </script>

--- a/packages/vue-cheetah-grid/lib/c-grid/header-utils.js
+++ b/packages/vue-cheetah-grid/lib/c-grid/header-utils.js
@@ -23,7 +23,7 @@ function vnodeToColumnProp (vnode) {
   }
   if (vnode.componentInstance &&
     typeof vnode.componentInstance.createColumn === 'function') {
-    return vnode.componentInstance.$_CGridColumn_getProps()
+    return vnode.componentInstance.getPropsObjectInternal()
   }
   // before instantiation?
   return undefined

--- a/packages/vue-cheetah-grid/lib/c-grid/utils.js
+++ b/packages/vue-cheetah-grid/lib/c-grid/utils.js
@@ -93,3 +93,10 @@ export function normalizeAction (action) {
   }
   return action
 }
+
+export const girdUpdateWatcher = {
+  handler () {
+    this.$_CGrid_nextTickUpdate()
+  },
+  deep: true
+}

--- a/packages/vue-cheetah-grid/lib/index.js
+++ b/packages/vue-cheetah-grid/lib/index.js
@@ -3,18 +3,41 @@ import CGrid from './CGrid.vue'
 import CGridColumn from './CGridColumn.vue'
 import CGridColumnGroup from './CGridColumnGroup.vue'
 import CGridButtonColumn from './CGridButtonColumn.vue'
+import CGridCheckColumn from './CGridCheckColumn.vue'
 import CGridPercentCompleteBarColumn from './CGridPercentCompleteBarColumn.vue'
 import CGridIconColumn from './CGridIconColumn.vue'
 import CGridInputColumn from './CGridInputColumn.vue'
 import CGridLinkColumn from './CGridLinkColumn.vue'
 import CGridMenuColumn from './CGridMenuColumn.vue'
 
-export { CGrid, CGridColumn, CGridButtonColumn, CGridPercentCompleteBarColumn, CGridIconColumn, CGridColumnGroup, CGridInputColumn, CGridLinkColumn, CGridMenuColumn }
+export {
+  CGrid,
+  CGridColumn,
+  CGridColumnGroup,
+  CGridCheckColumn,
+  CGridButtonColumn,
+  CGridPercentCompleteBarColumn,
+  CGridIconColumn,
+  CGridInputColumn,
+  CGridLinkColumn,
+  CGridMenuColumn
+}
 
 export default CGrid
 
 export function install (Vue) {
-  const components = { CGrid, CGridColumn, CGridButtonColumn, CGridPercentCompleteBarColumn, CGridIconColumn, CGridColumnGroup, CGridInputColumn, CGridLinkColumn, CGridMenuColumn }
+  const components = {
+    CGrid,
+    CGridColumn,
+    CGridColumnGroup,
+    CGridCheckColumn,
+    CGridButtonColumn,
+    CGridPercentCompleteBarColumn,
+    CGridIconColumn,
+    CGridInputColumn,
+    CGridLinkColumn,
+    CGridMenuColumn
+  }
   for (const name in components) {
     Vue.component(name, components[name])
   }

--- a/packages/vue-cheetah-grid/test/CGridButtonColumn.spec.js
+++ b/packages/vue-cheetah-grid/test/CGridButtonColumn.spec.js
@@ -8,7 +8,7 @@ const localVue = createLocalVue()
 localVue.use(CGrid)
 
 describe('c-grid-button-column', () => {
-  it('Button click', () => {
+  it('Should call the action, if click a button.', () => {
     const onAction = sinon.spy()
     const Component = {
       template: `
@@ -29,7 +29,9 @@ describe('c-grid-button-column', () => {
         }
       },
       methods: {
-        onAction
+        onAction () {
+          onAction({ record: 123 })
+        }
       }
     }
     const wrapper = mount(Component, {
@@ -40,7 +42,90 @@ describe('c-grid-button-column', () => {
     expect(rawGrid.header.length).to.equal(1)
     const [action] = rawGrid.header
     expect(action.action).to.be.an.instanceof(cheetahGrid.columns.action.Action)
-    action.action._action({ record: 123 })
+    rawGrid.fireListeners('click_cell', { row: 1, col: 0 })
     expect(onAction.getCall(0).args).to.deep.equal([{ record: 123 }])
+  })
+
+  it('Should not call the action, if click a disabled button.', () => {
+    const onAction = sinon.spy()
+    const Component = {
+      template: `
+    <c-grid style="height:100px;"
+      ref="grid"
+      :data="data"
+      :frozen-col-count="1">
+      <c-grid-button-column
+        disabled
+        @click="onAction"
+        caption="test">test</c-grid-button-column>
+    </c-grid>
+  `,
+      data () {
+        return {
+          data: [
+            { text: 'text' }
+          ]
+        }
+      },
+      methods: {
+        onAction () {
+          onAction({ record: 123 })
+        }
+      }
+    }
+    const wrapper = mount(Component, {
+      localVue,
+      attachToDocument: true
+    })
+    const { rawGrid } = wrapper.vm.$refs.grid
+    rawGrid.fireListeners('click_cell', { row: 1, col: 0 })
+    expect(onAction.called).to.equal(false)
+  })
+
+  it('Should be reactive the `disabled` property.', () => {
+    let onAction = sinon.spy()
+    const Component = {
+      template: `
+    <c-grid style="height:100px;"
+      ref="grid"
+      :data="data"
+      :frozen-col-count="1">
+      <c-grid-button-column
+        :disabled="disabled"
+        @click="onAction"
+        caption="test">test</c-grid-button-column>
+    </c-grid>
+  `,
+      data () {
+        return {
+          data: [
+            { text: 'text' }
+          ],
+          disabled: false
+        }
+      },
+      methods: {
+        onAction () {
+          onAction({ record: 123 })
+        }
+      }
+    }
+    const wrapper = mount(Component, {
+      localVue,
+      attachToDocument: true
+    })
+    const { rawGrid } = wrapper.vm.$refs.grid
+    rawGrid.fireListeners('click_cell', { row: 1, col: 0 })
+    expect(onAction.called).to.equal(true)
+
+    wrapper.vm.disabled = true
+    onAction = sinon.spy()
+    rawGrid.fireListeners('click_cell', { row: 1, col: 0 })
+    expect(onAction.called).to.equal(false)
+
+    wrapper.vm.disabled = false
+    onAction = sinon.spy()
+    rawGrid.fireListeners('click_cell', { row: 1, col: 0 })
+    expect(onAction.called).to.equal(true)
   })
 })

--- a/packages/vue-cheetah-grid/test/CGrid_update.spec.js
+++ b/packages/vue-cheetah-grid/test/CGrid_update.spec.js
@@ -74,9 +74,12 @@ describe('c-grid update', () => {
     let { rawGrid } = wrapper.vm.$refs.grid
     expect(rawGrid.header.length).to.equal(1)
 
-    wrapper.vm.showButton = true;
-    ({ rawGrid } = wrapper.vm.$refs.grid)
-    expect(rawGrid.header.length).to.equal(2)
+    wrapper.vm.showButton = true
+    return wrapper.vm.$nextTick()
+      .then(() => {
+        ({ rawGrid } = wrapper.vm.$refs.grid)
+        expect(rawGrid.header.length).to.equal(2)
+      })
   })
   it('CGrid no update header', () => {
     const Component = {

--- a/packages/vue-cheetah-grid/test/Sample.vue
+++ b/packages/vue-cheetah-grid/test/Sample.vue
@@ -5,11 +5,9 @@
       :data="data"
       :frozen-col-count="1"
     >
-      <c-grid-column
+      <c-grid-check-column
         :width="50"
         field="check"
-        column-type="check"
-        action="check"
       />
       <c-grid-column
         field="id"

--- a/packages/vue-cheetah-grid/test/disabled_test.html
+++ b/packages/vue-cheetah-grid/test/disabled_test.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html class="mdc-typography">
+<head>
+  <meta charset="utf-8">
+  <meta content="width=device-width, initial-scale=1" name="viewport">
+  <meta content="IE=edge" http-equiv="X-UA-Compatible">
+  <title>Loading...</title>
+  <script src="https://cdn.jsdelivr.net/npm/vue@2.5.17/dist/vue.js"></script>
+  <script src="../../cheetah-grid/dist/cheetahGrid.es5.min.js"></script>
+  <script src="../../vue-cheetah-grid/dist/vueCheetahGrid.js"></script>
+</head>
+<body>
+  <div id="app" style="height:300px;">
+    <c-grid
+      :data="data">
+      <c-grid-input-column
+        field="text"
+        :disabled="disabled"
+      >
+        INPUT
+      </c-grid-input-column>
+      <c-grid-menu-column
+        field="menu"
+        :options="options"
+        :disabled="disabled"
+      >
+        MENU
+      </c-grid-menu-column>
+      <c-grid-check-column
+        field="check"
+        :disabled="disabled"
+      >
+        CHECK
+      </c-grid-check-column>
+      <c-grid-button-column
+        @click="onClick"
+        caption="CLICK"
+        :disabled="disabled"
+      >
+        BUTTON
+      </c-grid-button-column>
+      <c-grid-button-column
+        @click="onToggleDisabled"
+        caption="TOGGLE DISABLED"
+      >
+        BUTTON
+      </c-grid-button-column>
+
+    </c-grid>
+  </div>
+  <script src="./disabled_test.js"></script>
+</body>
+</html>

--- a/packages/vue-cheetah-grid/test/disabled_test.js
+++ b/packages/vue-cheetah-grid/test/disabled_test.js
@@ -1,0 +1,30 @@
+/* global Vue,vueCheetahGrid */
+
+Vue.use(vueCheetahGrid)
+/* eslint-disable no-new */
+new Vue({
+  el: '#app',
+  data () {
+    return {
+      data: [
+        { text: 'text', menu: '01', check: true },
+        { text: 'text', menu: '01', check: true },
+        { text: 'text', menu: '01', check: true }
+      ],
+      options: [
+        { value: '01', caption: 'A' },
+        { value: '02', caption: 'B' },
+        { value: '03', caption: 'C' }
+      ],
+      disabled: true
+    }
+  },
+  methods: {
+    onClick (rec) {
+      alert(JSON.stringify(rec))
+    },
+    onToggleDisabled (rec) {
+      this.disabled = !this.disabled
+    }
+  }
+})

--- a/packages/vue-cheetah-grid/test/sample.spec.js
+++ b/packages/vue-cheetah-grid/test/sample.spec.js
@@ -13,7 +13,8 @@ describe('sample', () => {
   it('header config', () => {
     expect(rawGrid.header.length).to.equal(7)
     const [check, id, group, input, link, menu, percent] = rawGrid.header
-    expect(check).to.own.include({ 'caption': '', 'field': 'check', 'columnType': 'check', 'width': 50, 'action': 'check' })
+    expect(check).to.own.include({ 'caption': '', 'field': 'check', 'columnType': 'check', 'width': 50 })
+    expect(check.action).to.be.an.instanceof(cheetahGrid.columns.action.CheckEditor)
     expect(id).to.own.include({ 'caption': 'ID', 'field': 'id', 'width': '85' })
     //
     expect(group.caption).to.equal('GROUP')


### PR DESCRIPTION
- Added `disabled` property to each actionable column components.
    The target is with the following column components.
    - `CGridButtonColumn`
    - `CGridLinkColumn`
- Added `disabled` and `readonly` properties to each editable column components.
    The target is with the following column components.
    - `CGridInputColumn`
    - `CGridMenuColumn`
- Added `CGridCheckColumn` component.
- Changed the processing method, of to reflect column properties changed to the grid.