### PR TITLE
Add keyboard related options.

### DIFF
--- a/packages/cheetah-grid/src/.eslintrc.js
+++ b/packages/cheetah-grid/src/.eslintrc.js
@@ -24,7 +24,8 @@ module.exports = {
           'error',
           {'vars': 'all', 'args': 'none'}
         ],
-        "no-unused-expressions": "off"
+        "no-unused-expressions": "off",
+        '@typescript-eslint/no-non-null-assertion': 'off',
       }
     }
   ]

--- a/packages/cheetah-grid/src/js/columns/action/Action.ts
+++ b/packages/cheetah-grid/src/js/columns/action/Action.ts
@@ -74,4 +74,7 @@ export class Action<T> extends BaseAction<T> {
   onPasteCellRangeBox(): void {
     // noop
   }
+  onDeleteCellRangeBox(): void {
+    // noop
+  }
 }

--- a/packages/cheetah-grid/src/js/columns/action/BaseAction.ts
+++ b/packages/cheetah-grid/src/js/columns/action/BaseAction.ts
@@ -32,4 +32,5 @@ export abstract class BaseAction<T> {
     cell: CellAddress,
     value: string
   ): void;
+  abstract onDeleteCellRangeBox(grid: ListGridAPI<T>, cell: CellAddress): void;
 }

--- a/packages/cheetah-grid/src/js/columns/action/BaseInputEditor.ts
+++ b/packages/cheetah-grid/src/js/columns/action/BaseInputEditor.ts
@@ -116,8 +116,8 @@ export abstract class BaseInputEditor<T> extends Editor<T> {
 
         event.cancel(e.event);
       }),
-      grid.listen(DG_EVENT_TYPE.KEYDOWN, (keyCode, _e) => {
-        if (keyCode !== KEY_F2 && keyCode !== KEY_ENTER) {
+      grid.listen(DG_EVENT_TYPE.KEYDOWN, e => {
+        if (e.keyCode !== KEY_F2 && e.keyCode !== KEY_ENTER) {
           return;
         }
         const sel = grid.selection.select;
@@ -128,6 +128,7 @@ export abstract class BaseInputEditor<T> extends Editor<T> {
           col: sel.col,
           row: sel.row
         });
+        e.stopCellMoving();
       }),
       grid.listen(DG_EVENT_TYPE.SELECTED_CELL, e => {
         this.onChangeSelectCellInternal(
@@ -203,5 +204,14 @@ export abstract class BaseInputEditor<T> extends Editor<T> {
       return;
     }
     grid.doChangeValue(cell.col, cell.row, () => value);
+  }
+  onDeleteCellRangeBox(grid: ListGridAPI<T>, cell: CellAddress): void {
+    if (
+      isReadOnlyRecord(this.readOnly, grid, cell.row) ||
+      isDisabledRecord(this.disabled, grid, cell.row)
+    ) {
+      return;
+    }
+    grid.doChangeValue(cell.col, cell.row, () => "");
   }
 }

--- a/packages/cheetah-grid/src/js/columns/action/CheckEditor.ts
+++ b/packages/cheetah-grid/src/js/columns/action/CheckEditor.ts
@@ -10,9 +10,6 @@ import { getCheckColumnStateId } from "../../internal/symbolManager";
 
 const CHECK_COLUMN_STATE_ID = getCheckColumnStateId();
 
-const KEY_ENTER = 13;
-const KEY_SPACE = 32;
-
 function toggleValue(val: number): number;
 function toggleValue(val: string): string;
 function toggleValue(val: unknown): boolean;
@@ -131,8 +128,7 @@ export class CheckEditor<T> extends Editor<T> {
               row
             });
           }
-        },
-        acceptKeys: [KEY_ENTER, KEY_SPACE]
+        }
       }),
 
       // paste value
@@ -182,5 +178,8 @@ export class CheckEditor<T> extends Editor<T> {
         grid.doChangeValue(cell.col, cell.row, toggleValue);
       }
     });
+  }
+  onDeleteCellRangeBox(): void {
+    // noop
   }
 }

--- a/packages/cheetah-grid/src/js/columns/action/InlineMenuEditor.ts
+++ b/packages/cheetah-grid/src/js/columns/action/InlineMenuEditor.ts
@@ -132,14 +132,15 @@ export class InlineMenuEditor<T> extends Editor<T> {
           row: cell.row
         });
       }),
-      grid.listen(DG_EVENT_TYPE.KEYDOWN, (keyCode, _e) => {
-        if (keyCode !== KEY_F2 && keyCode !== KEY_ENTER) {
+      grid.listen(DG_EVENT_TYPE.KEYDOWN, e => {
+        if (e.keyCode !== KEY_F2 && e.keyCode !== KEY_ENTER) {
           return;
         }
         const sel = grid.selection.select;
         if (!isTarget(sel.col, sel.row)) {
           return;
         }
+        e.stopCellMoving();
         open({
           col: sel.col,
           row: sel.row
@@ -240,6 +241,18 @@ export class InlineMenuEditor<T> extends Editor<T> {
       grid.doChangeValue(cell.col, cell.row, () => pasteOpt.value);
     }
   }
+  onDeleteCellRangeBox(grid: ListGridAPI<T>, cell: CellAddress): void {
+    if (
+      isReadOnlyRecord(this.readOnly, grid, cell.row) ||
+      isDisabledRecord(this.disabled, grid, cell.row)
+    ) {
+      return;
+    }
+    const pasteOpt = this._pasteDataToOptionValue("", grid, cell);
+    if (pasteOpt) {
+      grid.doChangeValue(cell.col, cell.row, () => pasteOpt.value);
+    }
+  }
   private _pasteDataToOptionValue(
     value: string,
     grid: ListGridAPI<T>,
@@ -279,6 +292,7 @@ function _textToOptionValue(
   return undefined;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function normalizePasteValueStr(value: any): string {
   if (value == null) {
     return "";

--- a/packages/cheetah-grid/src/js/columns/action/actionBind.ts
+++ b/packages/cheetah-grid/src/js/columns/action/actionBind.ts
@@ -8,6 +8,7 @@ import { event, isPromise } from "../../internal/utils";
 import { DG_EVENT_TYPE } from "../../core/DG_EVENT_TYPE";
 
 const KEY_ENTER = 13;
+const KEY_SPACE = 32;
 export function bindCellClickAction<T>(
   grid: ListGridAPI<T>,
   cellId: LayoutObjectId,
@@ -86,11 +87,15 @@ export function bindCellKeyAction<T>(
   function isTarget(col: number, row: number): boolean {
     return grid.getLayoutCellId(col, row) === cellId;
   }
-  acceptKeys = [...acceptKeys, KEY_ENTER];
+  acceptKeys = [...acceptKeys, KEY_ENTER, KEY_SPACE];
   return [
     // enter key down
-    grid.listen(DG_EVENT_TYPE.KEYDOWN, (keyCode, e) => {
-      if (acceptKeys.indexOf(keyCode) === -1) {
+    grid.listen(DG_EVENT_TYPE.KEYDOWN, e => {
+      if (acceptKeys.indexOf(e.keyCode) === -1) {
+        return;
+      }
+      if (grid.keyboardOptions?.moveCellOnEnter && e.keyCode === KEY_ENTER) {
+        // When moving with the enter key, no action is taken with the enter key.
         return;
       }
       const sel = grid.selection.select;
@@ -104,7 +109,7 @@ export function bindCellKeyAction<T>(
         col: sel.col,
         row: sel.row
       });
-      event.cancel(e);
+      event.cancel(e.event);
     })
   ];
 }

--- a/packages/cheetah-grid/src/js/columns/action/internal/InlineInputElement.ts
+++ b/packages/cheetah-grid/src/js/columns/action/internal/InlineInputElement.ts
@@ -129,7 +129,7 @@ export class InlineInputElement<T> {
   }
   detach(gridFocus?: boolean): void {
     if (this._isActive()) {
-      const { grid, col, row } = this._activeData as ActiveData<T>;
+      const { grid, col, row } = this._activeData!;
       const input = this._input;
       this._handler.tryWithOffEvents(input, "blur", () => {
         input.parentElement?.removeChild(input);
@@ -148,7 +148,7 @@ export class InlineInputElement<T> {
     }
     const input = this._input;
     const { value } = input;
-    const { grid, col, row } = this._activeData as ActiveData<T>;
+    const { grid, col, row } = this._activeData!;
     grid.doChangeValue(col, row, () => value);
   }
   _isActive(): boolean {
@@ -182,36 +182,41 @@ export class InlineInputElement<T> {
       }
       const keyCode = event.getKeyCode(e);
       if (keyCode === KEY_ENTER) {
-        if (!this._isActive() || this._attaching) {
-          return;
-        }
-        const { grid } = this._activeData as ActiveData<T>;
-
-        this.doChangeValue();
-        if (grid) {
-          grid.focus();
-        }
-        this.detach();
-        event.cancel(e);
+        this._onKeydownEnter(e);
       } else if (keyCode === KEY_TAB) {
-        if (!this._isActive()) {
-          return;
-        }
-        const { grid } = this._activeData as ActiveData<T>;
-        if (!grid.keyboardOptions?.moveCellOnTab) {
-          return;
-        }
-        this.doChangeValue();
-        if (grid) {
-          grid.focus();
-        }
-        this.detach();
-        grid.onKeyDownMove(e);
+        this._onKeydownTab(e);
       }
     });
     handler.on(input, "blur", _e => {
       this.doChangeValue();
       this.detach();
     });
+  }
+  _onKeydownEnter(e: KeyboardEvent): void {
+    if (!this._isActive() || this._attaching) {
+      return;
+    }
+
+    const { grid } = this._activeData!;
+
+    this.doChangeValue();
+    this.detach(true);
+    event.cancel(e);
+
+    if (grid.keyboardOptions?.moveCellOnEnter) {
+      grid.onKeyDownMove(e);
+    }
+  }
+  _onKeydownTab(e: KeyboardEvent): void {
+    if (!this._isActive()) {
+      return;
+    }
+    const { grid } = this._activeData!;
+    if (!grid.keyboardOptions?.moveCellOnTab) {
+      return;
+    }
+    this.doChangeValue();
+    this.detach(true);
+    grid.onKeyDownMove(e);
   }
 }

--- a/packages/cheetah-grid/src/js/core/DG_EVENT_TYPE.ts
+++ b/packages/cheetah-grid/src/js/core/DG_EVENT_TYPE.ts
@@ -38,6 +38,7 @@ export interface DrawGridEvents {
   CONTEXTMENU_CELL: "contextmenu_cell";
   INPUT_CELL: "input_cell";
   PASTE_CELL: "paste_cell";
+  DELETE_CELL: "delete_cell";
   EDITABLEINPUT_CELL: "editableinput_cell";
   MODIFY_STATUS_EDITABLEINPUT_CELL: "modify_status_editableinput_cell";
   /**
@@ -72,6 +73,7 @@ export const DG_EVENT_TYPE: DrawGridEvents = {
   CONTEXTMENU_CELL: "contextmenu_cell",
   INPUT_CELL: "input_cell",
   PASTE_CELL: "paste_cell",
+  DELETE_CELL: "delete_cell",
   EDITABLEINPUT_CELL: "editableinput_cell",
   MODIFY_STATUS_EDITABLEINPUT_CELL: "modify_status_editableinput_cell",
   RESIZE_COLUMN: "resize_column",

--- a/packages/cheetah-grid/src/js/header/action/CheckHeaderAction.ts
+++ b/packages/cheetah-grid/src/js/header/action/CheckHeaderAction.ts
@@ -7,8 +7,6 @@ import { getCheckHeaderStateId } from "../../internal/symbolManager";
 import { obj } from "../../internal/utils";
 
 const CHECK_HEADER_STATE_ID = getCheckHeaderStateId();
-const KEY_ENTER = 13;
-const KEY_SPACE = 32;
 
 function getState<T>(grid: GridInternal<T>): CheckHeaderState {
   let state = grid[CHECK_HEADER_STATE_ID];
@@ -74,8 +72,7 @@ export class CheckHeaderAction<T> extends BaseAction<T> {
         }
       }),
       ...bindCellKeyAction(grid, cellId, {
-        action,
-        acceptKeys: [KEY_ENTER, KEY_SPACE]
+        action
       })
     ];
   }

--- a/packages/cheetah-grid/src/js/header/action/actionBind.ts
+++ b/packages/cheetah-grid/src/js/header/action/actionBind.ts
@@ -95,8 +95,12 @@ export function bindCellKeyAction<T>(
   }
   return [
     // enter key down
-    grid.listen(DG_EVENT_TYPE.KEYDOWN, (keyCode, e) => {
-      if (acceptKeys.indexOf(keyCode) === -1) {
+    grid.listen(DG_EVENT_TYPE.KEYDOWN, e => {
+      if (acceptKeys.indexOf(e.keyCode) === -1) {
+        return;
+      }
+      if (grid.keyboardOptions?.moveCellOnEnter && e.keyCode === KEY_ENTER) {
+        // When moving with the enter key, no action is taken with the enter key.
         return;
       }
       const sel = grid.selection.select;
@@ -107,7 +111,7 @@ export function bindCellKeyAction<T>(
         col: sel.col,
         row: sel.row
       });
-      event.cancel(e);
+      event.cancel(e.event);
     })
   ];
 }

--- a/packages/cheetah-grid/src/js/ts-types/events.ts
+++ b/packages/cheetah-grid/src/js/ts-types/events.ts
@@ -25,6 +25,12 @@ export type TouchCellEvent = CellAddress & {
   event: TouchEvent;
 };
 
+export type KeydownEvent = {
+  keyCode: number;
+  event: KeyboardEvent;
+  stopCellMoving(): void;
+};
+
 export interface PasteRangeBoxValues {
   readonly colCount: number;
   readonly rowCount: number;
@@ -40,6 +46,10 @@ export type PasteCellEvent = CellAddress & {
 
 export type InputCellEvent = CellAddress & {
   value: string;
+};
+
+export type DeleteCellEvent = CellAddress & {
+  event: KeyboardEvent;
 };
 
 export type ScrollEvent = {
@@ -65,9 +75,10 @@ export interface DrawGridEventHandlersEventMap {
   mouseup_cell: [MouseCellEvent];
   contextmenu_cell: [MouseCellEvent];
   dbltap_cell: [TouchCellEvent];
-  keydown: [number, KeyboardEvent];
+  keydown: [KeydownEvent];
   paste_cell: [PasteCellEvent];
   input_cell: [InputCellEvent];
+  delete_cell: [DeleteCellEvent];
   scroll: [ScrollEvent];
   editableinput_cell: [CellAddress];
   modify_status_editableinput_cell: [ModifyStatusEditableinputCellEvent];
@@ -92,6 +103,7 @@ export interface DrawGridEventHandlersReturnMap {
   keydown: void;
   paste_cell: void;
   input_cell: void;
+  delete_cell: void;
   scroll: void;
   editableinput_cell: boolean | void;
   modify_status_editableinput_cell: void;

--- a/packages/cheetah-grid/src/js/ts-types/grid-engine.ts
+++ b/packages/cheetah-grid/src/js/ts-types/grid-engine.ts
@@ -28,6 +28,9 @@ export type LayoutObjectId = number | string | symbol;
 
 export interface DrawGridKeyboardOptions {
   moveCellOnTab?: boolean;
+  moveCellOnEnter?: boolean;
+  deleteCellValueOnDel?: boolean;
+  selectAllOnCtrlA?: boolean;
 }
 
 export interface DrawGridAPI {

--- a/packages/cheetah-grid/src/test/ListGrid_sample.js
+++ b/packages/cheetah-grid/src/test/ListGrid_sample.js
@@ -63,7 +63,12 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 	const grid = new cheetahGrid.ListGrid({
 		parentElement: document.querySelector('#parent'),
 		allowRangePaste: true,
-		keyboardOptions: {moveCellOnTab: true},
+		keyboardOptions: {
+			moveCellOnTab: true,
+			selectAllOnCtrlA: true,
+			deleteCellValueOnDel: true,
+			moveCellOnEnter: true
+		},
 		header: [
 			{field: 'check', caption: 'check', width: 50, columnType: 'check', action: 'check'},
 			{

--- a/packages/cheetah-grid/src/test/ListGrid_sample_for_layout.js
+++ b/packages/cheetah-grid/src/test/ListGrid_sample_for_layout.js
@@ -83,7 +83,12 @@ Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deseru
 	const grid = new cheetahGrid.ListGrid({
 		parentElement: document.querySelector('#parent'),
 		allowRangePaste: true,
-		keyboardOptions: {moveCellOnTab: true},
+		keyboardOptions: {
+			moveCellOnTab: true,
+			selectAllOnCtrlA: true,
+			deleteCellValueOnDel: true,
+			moveCellOnEnter: true
+		},
 		layout: [
 			[
 				{

--- a/packages/cheetah-grid/src/test/specs/column/style/CheckStyle_spec.js
+++ b/packages/cheetah-grid/src/test/specs/column/style/CheckStyle_spec.js
@@ -189,27 +189,27 @@
 				col: 0,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 13, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 13, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 1,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 32, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 32, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 2,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 13, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 13, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 3,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 32, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 32, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 4,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 13, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 13, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 0,
 				row: 0,
@@ -238,12 +238,12 @@
 				col: 3,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 32, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 32, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 4,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 13, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 13, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 0,
 				row: 0,

--- a/packages/cheetah-grid/src/test/specs/column/type/CheckColumn_spec.js
+++ b/packages/cheetah-grid/src/test/specs/column/type/CheckColumn_spec.js
@@ -183,27 +183,27 @@
 				col: 0,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 13, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 13, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 1,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 32, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 32, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 2,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 13, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 13, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 3,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 32, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 32, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 4,
 				row: 1,
 			};
-			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, 13, e);
+			grid.fireListeners(cheetahGrid.ListGrid.EVENT_TYPE.KEYDOWN, {keyCode: 13, event: e, stopCellMoving() {}});
 			grid.selection.select = {
 				col: 0,
 				row: 0,

--- a/packages/docs/api/js/options/README.md
+++ b/packages/docs/api/js/options/README.md
@@ -9,22 +9,25 @@ order: 9000
 
 ### Constructor Options
 
-| Property                      | Type                 | Descrition                                                                                                                   |
-| :---------------------------- | :------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| header                        | HeadersDefine        | Define simple headers and layout. This property cannot be used with the `layout` property. See [Define Headers and Columns]. |
-| layout                        | LayoutDefine         | Define advanced headers and layout. This property cannot be used with the `header` property. See [Advanced Layout].          |
-| records                       | Array                | Records. This property cannot be used with the `dataSource` property. See [Grid Data].                                       |
-| dataSource                    | DataSource           | The data source that supplies the records. This property cannot be used with the `records` property. See [Grid Data].        |
-| parentElement                 | HTMLElement          | Specify the parent element.                                                                                                  |
-| frozenColCount                | number               | Specify the number of columns to be frozen to the left.                                                                      |
-| defaultRowHeight              | number               | Specify the default grid rows height.                                                                                        |
-| defaultColWidth               | number               | Specify the default grid columns width.                                                                                      |
-| headerRowHeight               | number[] / number    | Specify the header row(s) height.                                                                                            |
-| theme                         | ThemeDefine / string | Specify the theme. See [Theme].                                                                                              |
-| font                          | string               | Specify the default font.                                                                                                    |
-| underlayBackgroundColor       | string               | Specify the underlay background color.                                                                                       |
-| allowRangePaste               | boolean              | Specify `true` to allow pasting of the range. See [Examples of allowRangePaste].                                             |
-| keyboardOptions.moveCellOnTab | boolean              | Specify `true` to enable cell movement by tab key.                                                                           |
+| Property                             | Type                 | Descrition                                                                                                                   |
+| :----------------------------------- | :------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
+| header                               | HeadersDefine        | Define simple headers and layout. This property cannot be used with the `layout` property. See [Define Headers and Columns]. |
+| layout                               | LayoutDefine         | Define advanced headers and layout. This property cannot be used with the `header` property. See [Advanced Layout].          |
+| records                              | Array                | Records. This property cannot be used with the `dataSource` property. See [Grid Data].                                       |
+| dataSource                           | DataSource           | The data source that supplies the records. This property cannot be used with the `records` property. See [Grid Data].        |
+| parentElement                        | HTMLElement          | Specify the parent element.                                                                                                  |
+| frozenColCount                       | number               | Specify the number of columns to be frozen to the left.                                                                      |
+| defaultRowHeight                     | number               | Specify the default grid rows height.                                                                                        |
+| defaultColWidth                      | number               | Specify the default grid columns width.                                                                                      |
+| headerRowHeight                      | number[] / number    | Specify the header row(s) height.                                                                                            |
+| theme                                | ThemeDefine / string | Specify the theme. See [Theme].                                                                                              |
+| font                                 | string               | Specify the default font.                                                                                                    |
+| underlayBackgroundColor              | string               | Specify the underlay background color.                                                                                       |
+| allowRangePaste                      | boolean              | Specify `true` to allow pasting of the range. See [Examples of allowRangePaste].                                             |
+| keyboardOptions.moveCellOnTab        | boolean              | Specify `true` to enable cell movement by Tab key.                                                                           |
+| keyboardOptions.moveCellOnEnter      | boolean              | Specify `true` to enable cell movement by Enter key.                                                                         |
+| keyboardOptions.deleteCellValueOnDel | boolean              | Specify `true` to enable enable deletion of cell values with the Del and BS keys.                                            |
+| keyboardOptions.selectAllOnCtrlA     | boolean              | Specify `true` to enable selectt all cells by Ctrl + A key.                                                                  |
 
 [Define Headers and Columns]: ../headers_columns.md
 [Advanced Layout]: ../advanced_layout/README.md

--- a/packages/docs/api/js/options/keyboardOptions.md
+++ b/packages/docs/api/js/options/keyboardOptions.md
@@ -1,0 +1,79 @@
+---
+sidebarDepth: 3
+order: 20
+---
+
+# keyboardOptions
+
+You can set the keyboard operation.
+
+## Focus and Edit
+
+If not set, the user can operate the cell with the keyboard as follows.
+
+|           Cell            |       Arrow       | Ctrl (or Meta) + Arrow |    Home or End     |    Ctrl (or Meta) + Home or End    |                 Enter                 |        Tab        |               Space                |   Backspace    |     Delete     |
+| :-----------------------: | :---------------: | :--------------------: | :----------------: | :--------------------------------: | :-----------------------------------: | :---------------: | :--------------------------------: | :------------: | :------------: |
+|    Normal (can't Edit)    |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                  --                   |     (native)      |                 --                 |       --       |       --       |
+|           Input           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           Enter input mode.           |     (native)      | Enter input mode. And input space. |       --       |       --       |
+|    Input (Input Mode)     |  (input native)   |     (input native)     |   (input native)   |           (input native)           |   Apply input and exit input mode.    |     (native)      |           (input native)           | (input native) | (input native) |
+|       Inline Input        |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           Enter input mode.           |     (native)      | Enter input mode. And input space. |       --       |       --       |
+| Inline Input (Input Mode) |  (input native)   |     (input native)     |   (input native)   |           (input native)           |   Apply input and exit input mode.    |     (native)      |           (input native)           | (input native) | (input native) |
+|           Check           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                Toggle.                |     (native)      |              Toggle.               |       --       |       --       |
+|         Dropdown          |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |          Enter select mode.           |     (native)      |                 --                 |       --       |       --       |
+|  Dropdown (Select Mode)   | Change selection. |        (native)        |      (native)      |              (native)              | Apply selection and exit select mode. | Change selection. |                 --                 |       --       |       --       |
+|          Button           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                Action.                |     (native)      |              Action.               |       --       |       --       |
+
+### `moveCellOnTab`
+
+Set to `true` to enable cell movement by `Tab` key.  
+If `keyboardOptions.moveCellOnTab` is set to `true`, the user can operate the cell with the keyboard as follows.
+
+|           Cell            |       Arrow       | Ctrl (or Meta) + Arrow |    Home or End     |    Ctrl (or Meta) + Home or End    |                 Enter                 |                         Tab                         |               Space                |   Backspace    |     Delete     |
+| :-----------------------: | :---------------: | :--------------------: | :----------------: | :--------------------------------: | :-----------------------------------: | :-------------------------------------------------: | :--------------------------------: | :------------: | :------------: |
+|    Normal (can't Edit)    |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                  --                   |           **Move one to next on right.**            |                 --                 |       --       |       --       |
+|           Input           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           Enter input mode.           |           **Move one to next on right.**            | Enter input mode. And input space. |       --       |       --       |
+|    Input (Input Mode)     |  (input native)   |     (input native)     |   (input native)   |           (input native)           |   Apply input and exit input mode.    |                      (native)                       |           (input native)           | (input native) | (input native) |
+|       Inline Input        |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           Enter input mode.           |           **Move one to next on right.**            | Enter input mode. And input space. |       --       |       --       |
+| Inline Input (Input Mode) |  (input native)   |     (input native)     |   (input native)   |           (input native)           |   Apply input and exit input mode.    |           **Move one to next on right.**            |           (input native)           | (input native) | (input native) |
+|           Check           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                Toggle.                |           **Move one to next on right.**            |              Toggle.               |       --       |       --       |
+|         Dropdown          |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |          Enter select mode.           |           **Move one to next on right.**            |                 --                 |       --       |       --       |
+|  Dropdown (Select Mode)   | Change selection. |        (native)        |      (native)      |              (native)              | Apply selection and exit select mode. | **Move one to next on right.** And apply selection. |                 --                 |       --       |       --       |
+|          Button           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                Action.                |           **Move one to next on right.**            |              Action.               |       --       |       --       |
+
+### `moveCellOnEnter`
+
+Set to `true` to enable cell movement by `Enter` key.  
+If `keyboardOptions.moveCellOnEnter` is set to `true`, the user can operate the cell with the keyboard as follows.
+
+|           Cell            |       Arrow       | Ctrl (or Meta) + Arrow |    Home or End     |    Ctrl (or Meta) + Home or End    |                       Enter                        |                        Tab                        |               Space                |   Backspace    |     Delete     |
+| :-----------------------: | :---------------: | :--------------------: | :----------------: | :--------------------------------: | :------------------------------------------------: | :-----------------------------------------------: | :--------------------------------: | :------------: | :------------: |
+|    Normal (can't Edit)    |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           **Move one to next on down.**            |           *Move one to next on right.*            |                 --                 |       --       |       --       |
+|           Input           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                 Enter input mode.                  |           *Move one to next on right.*            | Enter input mode. And input space. |       --       |       --       |
+|    Input (Input Mode)     |  (input native)   |     (input native)     |   (input native)   |           (input native)           |   **Move one to next on down.** And apply input.   |                     (native)                      |           (input native)           | (input native) | (input native) |
+|       Inline Input        |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                 Enter input mode.                  |           *Move one to next on right.*            | Enter input mode. And input space. |       --       |       --       |
+| Inline Input (Input Mode) |  (input native)   |     (input native)     |   (input native)   |           (input native)           |   **Move one to next on down.** And apply input.   |           *Move one to next on right.*            |           (input native)           | (input native) | (input native) |
+|           Check           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           **Move one to next on down.**            |           *Move one to next on right.*            |              Toggle.               |       --       |       --       |
+|         Dropdown          |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                 Enter select mode.                 |           *Move one to next on right.*            |                 --                 |       --       |       --       |
+|  Dropdown (Select Mode)   | Change selection. |        (native)        |      (native)      |              (native)              | **Move one to next on down.** And apply selection. | *Move one to next on right.* And apply selection. |                 --                 |       --       |       --       |
+|          Button           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           **Move one to next on down.**            |           *Move one to next on right.*            |              Action.               |       --       |       --       |
+
+### `deleteCellValueOnDel`
+
+Set to `true` to enable enable deletion of cell values with the `Del` and `BS` keys.  
+If `keyboardOptions.deleteCellValueOnDel` is set to `true`, the user can operate the cell with the keyboard as follows.
+
+|           Cell            |       Arrow       | Ctrl (or Meta) + Arrow |    Home or End     |    Ctrl (or Meta) + Home or End    |                      Enter                       |                        Tab                        |               Space                |                     Backspace                     |                      Delete                       |
+| :-----------------------: | :---------------: | :--------------------: | :----------------: | :--------------------------------: | :----------------------------------------------: | :-----------------------------------------------: | :--------------------------------: | :-----------------------------------------------: | :-----------------------------------------------: |
+|    Normal (can't Edit)    |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           *Move one to next on down.*            |           *Move one to next on right.*            |                 --                 |                        --                         |                        --                         |
+|           Input           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                Enter input mode.                 |           *Move one to next on right.*            | Enter input mode. And input space. |                 **Delete value.**                 |                 **Delete value.**                 |
+|    Input (Input Mode)     |  (input native)   |     (input native)     |   (input native)   |           (input native)           |   *Move one to next on down.* And apply input.   |                     (native)                      |           (input native)           |                  (input native)                   |                  (input native)                   |
+|       Inline Input        |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                Enter input mode.                 |           *Move one to next on right.*            | Enter input mode. And input space. |                 **Delete value.**                 |                 **Delete value.**                 |
+| Inline Input (Input Mode) |  (input native)   |     (input native)     |   (input native)   |           (input native)           |   *Move one to next on down.* And apply input.   |           *Move one to next on right.*            |           (input native)           |                  (input native)                   |                  (input native)                   |
+|           Check           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           *Move one to next on down.*            |           *Move one to next on right.*            |              Toggle.               |                        --                         |                        --                         |
+|         Dropdown          |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |                Enter select mode.                |           *Move one to next on right.*            |                 --                 | **Delete value**, if the cell value can be empty. | **Delete value**, if the cell value can be empty. |
+|  Dropdown (Select Mode)   | Change selection. |        (native)        |      (native)      |              (native)              | *Move one to next on down.* And apply selection. | *Move one to next on right.* And apply selection. |                 --                 |                        --                         |                        --                         |
+|          Button           |     Move one.     |     Move to edge.      | Move to side edge. | Move to upper left or lower right. |           *Move one to next on down.*            |           *Move one to next on right.*            |              Action.               |                        --                         |                        --                         |
+
+### `selectAllOnCtrlA`
+
+Set to `true` to enable selectt all cells by `Ctrl + A`.  

--- a/packages/vue-cheetah-grid/lib/CGrid.vue
+++ b/packages/vue-cheetah-grid/lib/CGrid.vue
@@ -196,7 +196,7 @@ function _buildGridOption (vm) {
       defaultColWidth: vm.defaultColWidth,
       font: vm.font,
       underlayBackgroundColor: vm.underlayBackgroundColor,
-      keyboardOptions: { moveCellOnTab: vm.moveCellOnTabKey },
+      keyboardOptions: { moveCellOnTab: vm.moveCellOnTabKey, moveCellOnEnter: vm.moveCellOnEnterKey, deleteCellValueOnDel: vm.deleteCellValueOnDelKey, selectAllOnCtrlA: vm.selectAllOnCtrlAKey },
       disableColumnResize: vm.disableColumnResize
     },
     headerLayoutOptions,
@@ -301,9 +301,27 @@ export default {
       default: undefined
     },
     /**
-     * Specify `true` to enable cell movement by tab key.
+     * Specify `true` to enable cell movement by Tab key.
      */
     moveCellOnTabKey: {
+      type: Boolean
+    },
+    /**
+     * Specify `true` to enable cell movement by Enter key.
+     */
+    moveCellOnEnterKey: {
+      type: Boolean
+    },
+    /**
+     *  Specify `true` to enable enable deletion of cell values with the Del and BS keys.
+     */
+    deleteCellValueOnDelKey: {
+      type: Boolean
+    },
+    /**
+     *  Specify `true` to enable selectt all cells by Ctrl + A key.
+     */
+    selectAllOnCtrlAKey: {
       type: Boolean
     },
     /**
@@ -375,6 +393,18 @@ export default {
       if (this.rawGrid) {
         this.rawGrid.readOnly = readonly
       }
+    },
+    moveCellOnTabKey (moveCellOnTab) {
+      this.$_CGrid_updateKeyboardOptions({ moveCellOnTab })
+    },
+    moveCellOnEnterKey (moveCellOnEnter) {
+      this.$_CGrid_updateKeyboardOptions({ moveCellOnEnter })
+    },
+    deleteCellValueOnDelKey  (deleteCellValueOnDel) {
+      this.$_CGrid_updateKeyboardOptions({ deleteCellValueOnDel })
+    },
+    selectAllOnCtrlAKey  (selectAllOnCtrlA) {
+      this.$_CGrid_updateKeyboardOptions({ selectAllOnCtrlA })
     }
   },
   created () {
@@ -466,13 +496,13 @@ export default {
       this.$_CGrid_cancelNextTickUpdate()
       if (this.rawGrid) {
         const gridProps = _buildGridProps(this)
-        const beforeGridProps = extend({}, this._beforeGridProps)
-        if (deepObjectEquals(beforeGridProps, gridProps)) {
+        if (deepObjectEquals(this._beforeGridProps, gridProps)) {
           // optionの変更が無ければ、ここからの操作はしない
           return
         }
 
         const newProps = extend({}, gridProps)
+        const beforeGridProps = extend({}, this._beforeGridProps)
         delete beforeGridProps.header
         delete newProps.header
         delete beforeGridProps.layout
@@ -506,8 +536,12 @@ export default {
             font,
             underlayBackgroundColor
           } = options
-          this.rawGrid.header = header
-          this.rawGrid.layout = layout
+          if (!deepObjectEquals(this._beforeGridProps.header, gridProps.handler)) {
+            this.rawGrid.header = header
+          }
+          if (!deepObjectEquals(this._beforeGridProps.layout, gridProps.layout)) {
+            this.rawGrid.layout = layout
+          }
           this.rawGrid.frozenColCount = frozenColCount
           this.rawGrid.theme = theme
           this.rawGrid.allowRangePaste = !!allowRangePaste
@@ -594,6 +628,18 @@ export default {
         return
       }
       this.$_CGrid_defineColumns.splice(index, 1)
+    },
+    /**
+     * @private
+     */
+    $_CGrid_updateKeyboardOptions (options) {
+      if (this.rawGrid) {
+        if (this.rawGrid.keyboardOptions) {
+          this.rawGrid.keyboardOptions = Object.assign({}, this.rawGrid.keyboardOptions, options)
+        } else {
+          this.rawGrid.keyboardOptions = options
+        }
+      }
     }
   }
 }

--- a/packages/vue-cheetah-grid/lib/c-grid/ColumnMixin.vue
+++ b/packages/vue-cheetah-grid/lib/c-grid/ColumnMixin.vue
@@ -86,7 +86,12 @@ export default {
     getPropsObjectInternal () {
       const props = extend({}, this.$props)
       props.textContent = this.$el.textContent.trim()
-      return props
+
+      if (typeof this.normalizeProps !== 'function') {
+        return props
+      }
+      const normalized = this.normalizeProps(props)
+      return extend(props, normalized)
     },
     /**
      * @private

--- a/packages/vue-cheetah-grid/lib/c-grid/StdColumnMixin.vue
+++ b/packages/vue-cheetah-grid/lib/c-grid/StdColumnMixin.vue
@@ -65,8 +65,11 @@ export default {
     }
   },
   computed: {
+    fieldProxy () {
+      return typeof this.field === 'function' ? this._fieldProxy : this.field
+    },
     resolvedField () {
-      return this.filter ? filterToFn(this, this.field, this.filter) : this.field
+      return this.filter ? filterToFn(this, this.fieldProxy, this.filter) : this.fieldProxy
     }
   },
   watch: {
@@ -92,6 +95,16 @@ export default {
         style: this.columnStyle,
         icon: this.icon,
         message: this.message
+      }
+    },
+
+    _fieldProxy (...args) {
+      return typeof this.field === 'function' ? this.field(...args) : undefined
+    },
+
+    normalizeProps () {
+      return {
+        field: this.fieldProxy
       }
     }
   }


### PR DESCRIPTION
- Fixed a problem that Ctrl + Z to input start.
- Add `keyboardOptions.moveCellOnEnter` option to Grid.
- Add `keyboardOptions.deleteCellValueOnDel` option to Grid.
- Add `keyboardOptions.selectAllOnCtrlA` option to Grid.