### PR TITLE
fix sort state type to run sample code

### DIFF
--- a/packages/cheetah-grid/src/js/ListGrid.ts
+++ b/packages/cheetah-grid/src/js/ListGrid.ts
@@ -1044,7 +1044,7 @@ export class ListGrid<T> extends DrawGrid implements ListGridAPI<T> {
    * Sets the sort state.
    * If `null` to set, the sort state is initialized.
    */
-  set sortState(sortState: SortState) {
+  set sortState(sortState: SortState | null) {
     const oldState = this.sortState;
     let oldField;
     if (oldState.col >= 0 && oldState.row >= 0) {


### PR DESCRIPTION
null is not acceptable, but sample says use null to reset sort

https://future-architect.github.io/cheetah-grid/documents/api/js/advanced_header/column_sort.html#reset