### PR TITLE
react-cheetah-grid 0.2

### DIFF
--- a/packages/react-cheetah-grid/CHANGES.md
+++ b/packages/react-cheetah-grid/CHANGES.md
@@ -1,0 +1,11 @@
+# 0.2.0
+
+- New: `<CheetahGrid>`'s `data` props accepts array and DataSource classes (`records` and `dataSource` also available)
+- Fix document image path
+- Fix data sources import
+- Fix `defaultRowHeight` props update
+- Fix: `<CheetahGrid>`'s `data` or `records` props will reassign if the array is changed.
+
+# 0.1.0
+
+- Initial Release

--- a/packages/react-cheetah-grid/README.md
+++ b/packages/react-cheetah-grid/README.md
@@ -2,7 +2,7 @@
 
 React wrapper of ultra speed table component - [CheetahGrid](https://future-architect.github.io/cheetah-grid/#/)
 
-![screenshot](./doc/basic.png)
+![screenshot](https://raw.githubusercontent.com/future-architect/cheetah-grid/master/packages/react-cheetah-grid/doc/basic.png)
 
 ```tsx
 type Record = {
@@ -30,7 +30,7 @@ const records: Record[] = [
 
       <CheetahGrid
         style={{ flexGrow: 1 }}
-        records={records}
+        data={records}
         theme={"BASIC"}
       >
         <Column field="personid" width={50}>
@@ -74,18 +74,16 @@ Theme is described at [here](https://future-architect.github.io/cheetah-grid/doc
 
 ### Data Sources
 
+`data` props is required to accept data source.
 One of the following props are required.
 
-- `records`: Array data of table.
-- `dataSource`: Data source instance to supply table data to CheetahGrid. This is described at [here](https://future-architect.github.io/cheetah-grid/documents/api/js/grid_data/#using-cheetahgrid-data-datasource-object).
-
-Important notice of `<CheetahGrid>` is its editing feature modifies `records` directly. It is not match with React's manner.
+- `data`: Array data of table or `DataSource` instance to supply table data to CheetahGrid. This is described at [here](https://future-architect.github.io/cheetah-grid/documents/api/js/grid_data/#using-cheetahgrid-data-datasource-object).
 
 If you modify records data directly out side of `<CheetahGrid>` (for example, modify data from event handlers), call its instance's `revalidate()` method.
 
 ## Column Types
 
-![Columns](./doc/columns.png)
+![Columns](https://raw.githubusercontent.com/future-architect/cheetah-grid/master/packages/react-cheetah-grid/doc/columns.png)
 
 Supported column types:
 
@@ -211,7 +209,7 @@ function App() {
   return (
     <>
       <button>
-      <CheetahGrid records={props.records} instance={instanceRef}>
+      <CheetahGrid data={props.records} instance={instanceRef}>
         <Column field="id">ID</Column>
         <Column field="name">Name</Column>
       </CheetahGrid>
@@ -222,7 +220,7 @@ function App() {
 
 ### Cell Message
 
-![Message sample](./doc/message.png)
+![Message sample](https://raw.githubusercontent.com/future-architect/cheetah-grid/master/packages/react-cheetah-grid/doc/message.png)
 
 `message` props adds message to cells.
 
@@ -262,7 +260,7 @@ The function can return object instead of string. `"error"`, `"warning"`, `"info
 
 ### Sort
 
-![Sort sample](./doc/sort.png)
+![Sort sample](https://raw.githubusercontent.com/future-architect/cheetah-grid/master/packages/react-cheetah-grid/doc/sort.png)
 
 `sort` props add sorting feature. Just add `sort` props enables sorting feature that uses JavaScript standard comparison. Also you can specify sort function as well.
 
@@ -278,7 +276,7 @@ The function can return object instead of string. `"error"`, `"warning"`, `"info
             v1 === v2 ? 0 : v1 < v2 ? 1 : -1;
     records.sort((r1, r2) => compare(r1.personid, r2.personid));
     console.log("sorted:", records);
-    grid.records = records;
+    grid.data = records;
   }}
   field="personid"
 >
@@ -291,7 +289,7 @@ More detail information is [here](https://future-architect.github.io/cheetah-gri
 
 ### Header Type and Action
 
-![screenshot](./doc/headeraction.png)
+![screenshot](https://raw.githubusercontent.com/future-architect/cheetah-grid/master/packages/react-cheetah-grid/doc/headeraction.png)
 
 You can customize header types and actions in addition to body cells types and actions.
 
@@ -322,7 +320,7 @@ const onChangeHeaderValue = useCallback(
 <CheetahGrid
   instance={instanceRef}
   style={{ flexGrow: 1 }}
-  records={records}
+  data={records}
   frozenColCount={2}
   onHeaderValueChange={onChangeHeaderValue}
 >
@@ -335,7 +333,7 @@ const onChangeHeaderValue = useCallback(
 
 ### Complex Layout
 
-![screenshot](./doc/layout.png)
+![screenshot](https://raw.githubusercontent.com/future-architect/cheetah-grid/master/packages/react-cheetah-grid/doc/layout.png)
 
 It supports complex layout like multi row headers and bodies.
 
@@ -353,7 +351,7 @@ The `<Line>` component enables to support multi row header and body. `rowSpan` a
 ```tsx
 <CheetahGrid
   style={{ flexGrow: 1 }}
-  records={records}
+  data={records}
   frozenColCount={2}
   theme={"BASIC"}
 >

--- a/packages/react-cheetah-grid/package-lock.json
+++ b/packages/react-cheetah-grid/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-cheetah-grid",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "react-cheetah-grid",
-      "version": "0.1.1",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "cheetah-grid": "^1.1.7",

--- a/packages/react-cheetah-grid/package.json
+++ b/packages/react-cheetah-grid/package.json
@@ -1,11 +1,11 @@
 {
   "name": "react-cheetah-grid",
   "license": "MIT",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "scripts": {
     "dev": "vite",
     "build": "tsc && vite build",
-    "postbuild": "tsc src/* --declaration --emitDeclarationOnly --jsx react-jsx --esModuleInterop --target es2020 --outDir dist --moduleResolution node",
+    "postbuild": "tsc src/* --declaration --emitDeclarationOnly --jsx react-jsx --esModuleInterop --target es2020 --out dist/index.d.ts --moduleResolution node",
     "serve": "vite preview",
     "test": "jest"
   },

--- a/packages/react-cheetah-grid/sample/Columns.tsx
+++ b/packages/react-cheetah-grid/sample/Columns.tsx
@@ -155,7 +155,7 @@ export function Columns() {
     <div className="h-full w-full flex flex-col items-stretch">
       <CheetahGrid
         style={{ flexGrow: 1 }}
-        records={records}
+        data={records}
         defaultRowHeight={100}
         headerRowHeight={24}
       >

--- a/packages/react-cheetah-grid/sample/Events.tsx
+++ b/packages/react-cheetah-grid/sample/Events.tsx
@@ -85,7 +85,7 @@ export function Events() {
     <div className="h-full w-full flex flex-row items-stretch">
       <CheetahGrid
         style={{ flexGrow: 1 }}
-        records={records}
+        data={records}
         onCellClick={(e) => {
           console.log("onCellClick", e);
           appendLog("onCellClick", e);

--- a/packages/react-cheetah-grid/sample/HeaderAction.tsx
+++ b/packages/react-cheetah-grid/sample/HeaderAction.tsx
@@ -109,7 +109,7 @@ export function HeaderAction() {
       <CheetahGrid
         instance={instanceRef}
         style={{ flexGrow: 1 }}
-        records={records}
+        data={records}
         frozenColCount={2}
         onHeaderValueChange={onChangeHeaderValue}
       >

--- a/packages/react-cheetah-grid/sample/Icon.tsx
+++ b/packages/react-cheetah-grid/sample/Icon.tsx
@@ -15,7 +15,7 @@ const records: Record[] = [
 export function Icon() {
   return (
     <div className="h-full w-full flex flex-row items-stretch">
-      <CheetahGrid style={{ flexGrow: 1 }} records={records}>
+      <CheetahGrid style={{ flexGrow: 1 }} data={records}>
         <Column
           field="text"
           width={180}

--- a/packages/react-cheetah-grid/sample/Message.tsx
+++ b/packages/react-cheetah-grid/sample/Message.tsx
@@ -132,7 +132,7 @@ const options = [
 export function Message() {
   return (
     <div className="h-full w-full flex flex-row items-stretch">
-      <CheetahGrid style={{ flexGrow: 1 }} records={records}>
+      <CheetahGrid style={{ flexGrow: 1 }} data={records}>
         <Column field={"text1"} width={150} message="msg">
           Msg from data
         </Column>

--- a/packages/react-cheetah-grid/sample/Selection.tsx
+++ b/packages/react-cheetah-grid/sample/Selection.tsx
@@ -63,7 +63,7 @@ export function Selection() {
     <div className="h-full w-full flex flex-col items-stretch">
       <CheetahGrid
         style={{ flexGrow: 1 }}
-        dataSource={dataSource}
+        data={dataSource}
         instance={instanceRef}
         onCellSelect={cellSelectCallback}
       >

--- a/packages/react-cheetah-grid/sample/Sort.tsx
+++ b/packages/react-cheetah-grid/sample/Sort.tsx
@@ -104,7 +104,7 @@ export function Sort() {
       <CheetahGrid
         instance={instanceRef}
         style={{ flexGrow: 1 }}
-        records={records}
+        data={records}
         frozenColCount={2}
       >
         <HeaderLayout>

--- a/packages/react-cheetah-grid/sample/Theme.tsx
+++ b/packages/react-cheetah-grid/sample/Theme.tsx
@@ -119,7 +119,7 @@ export function Theme() {
     <div className="h-full w-full flex flex-col items-stretch">
       <CheetahGrid
         style={{ flexGrow: 1 }}
-        records={records}
+        data={records}
         frozenColCount={2}
         theme={theme}
       >

--- a/packages/react-cheetah-grid/src/CheetahGrid.tsx
+++ b/packages/react-cheetah-grid/src/CheetahGrid.tsx
@@ -44,6 +44,7 @@ import {
   CheetahGridProps,
   isDataSourceProps,
   isStaticRecordProps,
+  isDataProps,
 } from "./gridProps";
 
 // Columns
@@ -267,6 +268,7 @@ export function parseLayout<T>(children: CheetahGridChildren<T>): {
 export class CheetahGrid<T> extends Component<CheetahGridProps<T>> {
   cgRef: RefObject<HTMLDivElement>;
   grid?: ListGrid<T>;
+  records?: T[];
 
   constructor(props: CheetahGridProps<T>) {
     super(props);
@@ -274,13 +276,7 @@ export class CheetahGrid<T> extends Component<CheetahGridProps<T>> {
   }
 
   shouldComponentUpdate(nextProps: CheetahGridProps<T>, _nextState: {}) {
-    const {
-      children,
-      frozenColCount,
-      defaultRowHeight,
-      headerRowHeight,
-      theme,
-    } = nextProps;
+    const { children, frozenColCount, defaultRowHeight, theme } = nextProps;
     if (this.grid) {
       const { layout, header } = parseLayout(children);
       if (layout) {
@@ -294,11 +290,25 @@ export class CheetahGrid<T> extends Component<CheetahGridProps<T>> {
       if (frozenColCount && this.grid.frozenColCount !== frozenColCount) {
         this.grid.frozenColCount = frozenColCount;
       }
-      if (frozenColCount && this.grid.frozenColCount !== frozenColCount) {
-        this.grid.frozenColCount = frozenColCount;
+      if (defaultRowHeight && this.grid.defaultRowHeight !== defaultRowHeight) {
+        this.grid.defaultRowHeight = defaultRowHeight;
       }
       if (theme && this.grid.theme !== theme) {
         this.grid.theme = cheetahGrid.themes.of(theme);
+      }
+      if (isStaticRecordProps<T>(this.props)) {
+        if (!Object.is(this.props.records, this.records)) {
+          this.grid.records = this.props.records;
+          this.records = this.props.records;
+        }
+      } else if (isDataProps<T>(this.props)) {
+        if (
+          Array.isArray(this.props.data) &&
+          !Object.is(this.props.data, this.records)
+        ) {
+          this.grid.records = this.props.data;
+          this.records = this.props.data;
+        }
       }
     }
     return false;
@@ -323,8 +333,18 @@ export class CheetahGrid<T> extends Component<CheetahGridProps<T>> {
 
     if (isStaticRecordProps<T>(this.props)) {
       opt.records = this.props.records;
+      this.records = this.props.records;
     } else if (isDataSourceProps<T>(this.props)) {
       opt.dataSource = this.props.dataSource;
+      this.records = undefined;
+    } else if (isDataProps<T>(this.props)) {
+      if (Array.isArray(this.props.data)) {
+        opt.records = this.props.data;
+        this.records = this.props.data;
+      } else {
+        opt.dataSource = this.props.data;
+        this.records = undefined;
+      }
     }
     const { layout, header } = parseLayout(children);
     if (layout) {

--- a/packages/react-cheetah-grid/src/gridProps.ts
+++ b/packages/react-cheetah-grid/src/gridProps.ts
@@ -91,7 +91,15 @@ export function isDataSourceProps<T>(value: {}): value is DataSourceProps<T> {
   return "dataSource" in value;
 }
 
-type SourceProps<T> = StaticRecordProps<T> | DataSourceProps<T>;
+type DataProps<T> = {
+  data: T[] | DataSource<T>;
+};
+
+export function isDataProps<T>(value: {}): value is DataProps<T> {
+  return "data" in value;
+}
+
+type SourceProps<T> = DataProps<T> | StaticRecordProps<T> | DataSourceProps<T>;
 
 export type CheetahGridProps<T> = CheetahGridStdProps<T> &
   CheetahGridEventProps<T> &

--- a/packages/react-cheetah-grid/src/index.ts
+++ b/packages/react-cheetah-grid/src/index.ts
@@ -1,5 +1,8 @@
 export { CheetahGrid } from "./CheetahGrid";
-export { useCheetahGridInstance } from "./useCheetahGridInstance";
+export {
+  useCheetahGridInstance,
+  CheetahGridInstance,
+} from "./useCheetahGridInstance";
 
 export type { Message } from "cheetah-grid/ts-types/data";
 export type { ColumnIconOption } from "cheetah-grid/ts-types";
@@ -53,10 +56,9 @@ export type { BranchGraphCommand } from "cheetah-grid/ts-types/column/type";
 // Layout
 export { HeaderLayout, BodyLayout, Line, Header } from "./Layout";
 
-// Data Source
-
 import * as cheetahGrid from "cheetah-grid";
 
+// Data Source
 export const { DataSource, CachedDataSource, FilterDataSource } =
   cheetahGrid.data;
 


### PR DESCRIPTION
- New: `<CheetahGrid>`'s `data` props accepts array and DataSource classes (`records` and `dataSource` also available)
- Fix document image path
- Fix data sources import
- Fix `defaultRowHeight` props update
- Fix: `<CheetahGrid>`'s `data` or `records` props will reassign if the array is changed.